### PR TITLE
fix: fix crash when WorkoutActivityType is unknown

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -476,13 +476,8 @@
             return @"MixedCardio";
         case HKWorkoutActivityTypeHandCycling:
             return @"HandCycling";
-        default:{
-            NSException *e = [NSException
-                              exceptionWithName:@"HKWorkoutActivityType InvalidValue"
-                              reason:@"HKWorkoutActivityType can only have a value from the HKWorkoutActivityType enum"
-                              userInfo:nil];
-            @throw e;
-        }
+        default:
+            return @"Other";
     }
 }
 


### PR DESCRIPTION
Apple keeps adding more workout types. For instance, iOS 14 added "socialDance" type.

Current implementation crashes if a new type appears. This tiny change makes sure that the crash never happens.