### PR TITLE
Remove getWorkout method from the library

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -59,25 +59,33 @@
     NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
 
     HKSampleType *samplesType = [RCTAppleHealthKit hkQuantityTypeFromString:type];
+
+    void (^completion)(NSArray *results, NSError *error);
+
+    completion = ^(NSArray *results, NSError *error) {
+        if (results){
+            callback(@[[NSNull null], results]);
+
+            return;
+        } else {
+            NSLog(@"error getting samples: %@", error);
+            callback(@[RCTMakeError(@"error getting samples", nil, nil)]);
+
+            return;
+        }
+    };
+
+
     if ([type isEqual:@"Running"] || [type isEqual:@"Cycling"]) {
         unit = [HKUnit mileUnit];
     }
-    NSLog(@"error getting samples: %@", [samplesType identifier]);
+
     [self fetchSamplesOfType:samplesType
-                                unit:unit
-                           predicate:predicate
-                           ascending:ascending
-                               limit:limit
-                          completion:^(NSArray *results, NSError *error) {
-                              if(results){
-                                  callback(@[[NSNull null], results]);
-                                  return;
-                              } else {
-                                  NSLog(@"error getting samples: %@", error);
-                                  callback(@[RCTMakeError(@"error getting samples", nil, nil)]);
-                                  return;
-                              }
-                          }];
+                        unit:unit
+                   predicate:predicate
+                   ascending:ascending
+                       limit:limit
+                  completion:completion];
 }
 
 - (void)fitness_setObserver:(NSDictionary *)input

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Sleep.m
@@ -13,7 +13,6 @@
 @implementation RCTAppleHealthKit (Methods_Sleep)
 
 
-
 - (void)sleep_getSleepSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.h
@@ -10,7 +10,6 @@
 
 @interface RCTAppleHealthKit (Methods_Workout)
 
--(void)workout_get:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
--(void)workout_save: (NSDictionary *)input callback: (RCTResponseSenderBlock)callback;
+- (void)workout_save: (NSDictionary *)input callback: (RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.m
@@ -12,36 +12,7 @@
 
 @implementation RCTAppleHealthKit (Methods_Workout)
 
-- (void)workout_get:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
-{
-    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
-    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
-    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:[NSDate date]];
-    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
-
-    NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
-
-    void (^completion)(NSArray *results, NSError *error);
-
-    completion = ^(NSArray *results, NSError *error) {
-        if(results){
-            callback(@[[NSNull null], results]);
-            return;
-        } else {
-            NSString *errMsg = [NSString stringWithFormat:@"Error getting samples: %@", error];
-            NSLog(errMsg);
-            callback(@[RCTMakeError(errMsg, nil, nil)]);
-            return;
-        }
-    };
-
-    [self fetchWorkoutForPredicate: predicate
-                         ascending:ascending
-                             limit:limit
-                        completion:completion];
-}
-
--(void)workout_save: (NSDictionary *)input callback: (RCTResponseSenderBlock)callback {
+- (void)workout_save: (NSDictionary *)input callback: (RCTResponseSenderBlock)callback {
     HKWorkoutActivityType type = [RCTAppleHealthKit hkWorkoutActivityTypeFromOptions:input key:@"type" withDefault:HKWorkoutActivityTypeAmericanFootball];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
     NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:nil];
@@ -57,16 +28,15 @@
     void (^completion)(BOOL success, NSError *error);
 
     completion = ^(BOOL success, NSError *error){
-        if(!success) {
-
+        if (!success) {
             NSLog(@"An error occured saving the workout %@. The error was: %@.", workout, error);
             callback(@[RCTMakeError(@"An error occured saving the workout", error, nil)]);
+
             return;
         }
         callback(@[[NSNull null], [[workout UUID] UUIDString]]);
     };
 
     [self.healthStore saveObject:workout withCompletion:completion];
-
 }
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -270,11 +270,6 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
     [self mindfulness_saveMindfulSession:input callback:callback];
 }
 
-RCT_EXPORT_METHOD(getWorkout:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
-{
-    [self workout_get:input callback:callback];
-}
-
 RCT_EXPORT_METHOD(saveWorkout:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self workout_save:input callback:callback];

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ they are splitted in the following categories
   * [saveBmi](/docs/saveBmi.md)
 
 #### Workout Methods
-  * [getWorkout](/docs/getWorkout.md)
+  * [getSamples](docs/getSamples.md)
   * [saveWorkout](/docs/saveWorkout.md)
 
 ## Additional Information

--- a/docs/getWorkout.md
+++ b/docs/getWorkout.md
@@ -1,3 +1,0 @@
-# Get Workout
-
-> Oops! Seems that we don't have documentation for this method yet. Feel free to contribute opening a new PR


### PR DESCRIPTION
## Summary

This appeared as a bug request. The library currently contains 2 ways of getting workouts that are, essentially, the same

- Via `getSamples()` method
- Via `getWorkouts()` method

The disadvantages of the second one are the following

- Lack of documentation, in comparison with the `getSamples()`
- Reduced amount of information being returned to the developer, as the first one returns "sourceName" & "sourceId"

## References

- #20 