### PR TITLE
Add permission for AppleExerciseTime

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -59,6 +59,8 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierNikeFuel];
     } else if ([@"AppleStandTime" isEqualToString: key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleStandTime];
+    } else if ([@"AppleExerciseTime" isEqualToString: key] && systemVersion >= 9.3) {
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleExerciseTime];
     }
 
     // Nutrition Identifiers


### PR DESCRIPTION
## Summary

This appeared as a bug request. The library currently supports getting `appleExerciseTime`, however, the permissions to achieve that were removed

This PR adds the permissions back to the native library

## References

- #22 