### PR TITLE
Add KCal unit, standardize options for all Activity methods, export getAppleStandTime 

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
@@ -14,9 +14,12 @@
 - (void)activity_getActiveEnergyBurned:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     HKQuantityType *activeEnergyType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierActiveEnergyBurned];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit kilocalorieUnit]];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
     NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
-    HKUnit *cal = [HKUnit kilocalorieUnit];
+    NSUInteger period = [RCTAppleHealthKit uintFromOptions:input key:@"period" withDefault:60];
+    BOOL includeManuallyAdded = [RCTAppleHealthKit boolFromOptions:input key:@"includeManuallyAdded" withDefault:true];
 
     if(startDate == nil){
         callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
@@ -24,11 +27,13 @@
     }
 
     [self fetchCumulativeSumStatisticsCollection:activeEnergyType
-                                            unit:cal
+                                            unit:unit
+                                          period:period
                                        startDate:startDate
                                          endDate:endDate
-                                       ascending:false
+                                       ascending:ascending
                                            limit:HKObjectQueryNoLimit
+                            includeManuallyAdded:includeManuallyAdded
                                       completion:^(NSArray *results, NSError *error) {
                                           if(results){
                                               callback(@[[NSNull null], results]);

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Activity.m
@@ -49,9 +49,12 @@
 - (void)activity_getBasalEnergyBurned:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     HKQuantityType *basalEnergyType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBasalEnergyBurned];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit kilocalorieUnit]];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
     NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
-    HKUnit *cal = [HKUnit kilocalorieUnit];
+    NSUInteger period = [RCTAppleHealthKit uintFromOptions:input key:@"period" withDefault:60];
+    BOOL includeManuallyAdded = [RCTAppleHealthKit boolFromOptions:input key:@"includeManuallyAdded" withDefault:true];
 
     if(startDate == nil){
         callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
@@ -59,30 +62,35 @@
     }
 
     [self fetchCumulativeSumStatisticsCollection:basalEnergyType
-                                                unit:cal
-                                        startDate:startDate
-                                            endDate:endDate
-                                        ascending:false
-                                            limit:HKObjectQueryNoLimit
-                                        completion:^(NSArray *results, NSError *error) {
-                                            if(results){
-                                                callback(@[[NSNull null], results]);
-                                                return;
-                                            } else {
-                                                NSLog(@"error getting basal energy burned samples: %@", error);
-                                                callback(@[RCTMakeError(@"error getting basal energy burned samples", nil, nil)]);
-                                                return;
-                                            }
-                                        }];
+                                            unit:unit
+                                          period:period
+                                       startDate:startDate
+                                         endDate:endDate
+                                       ascending:ascending
+                                           limit:HKObjectQueryNoLimit
+                            includeManuallyAdded:includeManuallyAdded
+                                      completion:^(NSArray *results, NSError *error) {
+                                          if(results){
+                                              callback(@[[NSNull null], results]);
+                                              return;
+                                          } else {
+                                              NSLog(@"error getting basal energy burned samples: %@", error);
+                                              callback(@[RCTMakeError(@"error getting basal energy burned samples", nil, nil)]);
+                                              return;
+                                          }
+                                      }];
 }
 
 
 - (void)activity_getAppleExerciseTime:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     HKQuantityType *exerciseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleExerciseTime];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit secondUnit]];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
     NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
-    HKUnit *unit = [HKUnit secondUnit];
+    NSUInteger period = [RCTAppleHealthKit uintFromOptions:input key:@"period" withDefault:60];
+    BOOL includeManuallyAdded = [RCTAppleHealthKit boolFromOptions:input key:@"includeManuallyAdded" withDefault:true];
 
     if(startDate == nil){
         callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
@@ -91,10 +99,12 @@
 
     [self fetchCumulativeSumStatisticsCollection:exerciseType
                                             unit:unit
+                                          period:period
                                        startDate:startDate
                                          endDate:endDate
-                                       ascending:false
+                                       ascending:ascending
                                            limit:HKObjectQueryNoLimit
+                            includeManuallyAdded:includeManuallyAdded
                                       completion:^(NSArray *results, NSError *error) {
                                           if(results){
                                               callback(@[[NSNull null], results]);
@@ -110,9 +120,12 @@
 - (void)activity_getAppleStandTime:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     HKQuantityType *exerciseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleStandTime];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit secondUnit]];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
     NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
-    HKUnit *unit = [HKUnit secondUnit];
+    NSUInteger period = [RCTAppleHealthKit uintFromOptions:input key:@"period" withDefault:60];
+    BOOL includeManuallyAdded = [RCTAppleHealthKit boolFromOptions:input key:@"includeManuallyAdded" withDefault:true];
 
     if(startDate == nil){
         callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
@@ -121,10 +134,12 @@
 
     [self fetchCumulativeSumStatisticsCollection:exerciseType
                                             unit:unit
+                                          period:period
                                        startDate:startDate
                                          endDate:endDate
-                                       ascending:false
+                                       ascending:ascending
                                            limit:HKObjectQueryNoLimit
+                            includeManuallyAdded:includeManuallyAdded
                                       completion:^(NSArray *results, NSError *error) {
                                           if(results){
                                               callback(@[[NSNull null], results]);

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -387,6 +387,8 @@
     BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
     NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    NSUInteger period = [RCTAppleHealthKit uintFromOptions:input key:@"period" withDefault:60];
+    BOOL includeManuallyAdded = [RCTAppleHealthKit boolFromOptions:input key:@"includeManuallyAdded" withDefault:true];
     if(startDate == nil){
         callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
         return;
@@ -396,10 +398,12 @@
 
     [self fetchCumulativeSumStatisticsCollection:quantityType
                                             unit:unit
+                                          period:period
                                        startDate:startDate
                                          endDate:endDate
                                        ascending:ascending
                                            limit:limit
+                           includeManuallyAdded:includeManuallyAdded
                                       completion:^(NSArray *arr, NSError *err){
                                           if (err != nil) {
                                               callback(@[RCTJSErrorFromNSError(err)]);

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -403,7 +403,7 @@
                                          endDate:endDate
                                        ascending:ascending
                                            limit:limit
-                           includeManuallyAdded:includeManuallyAdded
+                            includeManuallyAdded:includeManuallyAdded
                                       completion:^(NSArray *arr, NSError *err){
                                           if (err != nil) {
                                               callback(@[RCTJSErrorFromNSError(err)]);

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -210,6 +210,11 @@ RCT_EXPORT_METHOD(getAppleExerciseTime:(NSDictionary *)input callback:(RCTRespon
     [self activity_getAppleExerciseTime:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getAppleStandTime:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self activity_getAppleStandTime:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getVo2MaxSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self vitals_getVo2MaxSamples:input callback:callback];

--- a/index.d.ts
+++ b/index.d.ts
@@ -158,22 +158,22 @@ declare module 'react-native-health' {
 
     getActiveEnergyBurned(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getBasalEnergyBurned(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getAppleExerciseTime(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getAppleStandTime(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getVo2MaxSamples(

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ declare module 'react-native-health' {
 
     getDailyDistanceWalkingRunningSamples(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getDistanceCycling(
@@ -118,7 +118,7 @@ declare module 'react-native-health' {
 
     getDailyDistanceCyclingSamples(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getFlightsClimbed(
@@ -128,7 +128,7 @@ declare module 'react-native-health' {
 
     getDailyFlightsClimbedSamples(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     saveFood(
@@ -306,6 +306,7 @@ declare module 'react-native-health' {
     type?: HealthObserver
     date?: string
     includeManuallyAdded?: boolean
+    period?: number
   }
 
   export interface HealthValueOptions extends HealthUnitOptions {
@@ -479,6 +480,7 @@ declare module 'react-native-health' {
     hour = 'hour',
     inch = 'inch',
     joule = 'joule',
+    kilocalorie = 'kilocalorie',
     meter = 'meter',
     mgPerdL = 'mgPerdL',
     mile = 'mile',

--- a/src/constants/Units.js
+++ b/src/constants/Units.js
@@ -15,6 +15,7 @@ export const Units = {
   hour: 'hour',
   inch: 'inch',
   joule: 'joule',
+  kilocalorie: 'kilocalorie',
   meter: 'meter',
   mgPerdL: 'mgPerdL',
   mile: 'mile',


### PR DESCRIPTION
Thanks for starting this repo! Happy to help out where I can. Here are a few fixes for adding common args to some sample queries I'm using to start. 

- Add kilocalorie unit
- Add `period` as an input option
- Fix return types for a few other sample queries
- Standardize options for all Activity methods
- Export missing method to use getAppleStandTime