### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A React Native package to interact with Apple HealthKit for iOS.
 
 ### Automatic Installation
 
-Install the react-native-health package from [npm](https://www.npmjs.com/package/react-native-health)
+1. Install the react-native-health package from [npm](https://www.npmjs.com/package/react-native-health)
 
 ```
 yarn add react-native-health
 ```
 
-If you are using [CocoaPods](https://cocoapods.org/) you can run the following
+2. If you are using [CocoaPods](https://cocoapods.org/) you can run the following
 from the `ios/` folder of your app
 
 ```
@@ -26,7 +26,7 @@ Or, if you need to manually link it, run
 react-native link react-native-health
 ```
 
-Update the `ios/<Project Name>/info.plist` file in your project
+3. Update the `ios/<Project Name>/info.plist` file in your project
 ```
 <key>NSHealthShareUsageDescription</key>
 <string>Read and understand health data.</string>
@@ -77,7 +77,7 @@ AppleHealthKit.initHealthKit(permissions, (error: string) => {
   AppleHealthKit.getHeartRateSamples(options, (callbackError: string, results: HealthValue[]) => {
     /* Samples are now collected from HealthKit */
   });
-}
+});
 ```
 
 ## Documentation


### PR DESCRIPTION
It wasn't clear to me that the step to update `info.plist` was necessary if you did `pod install`, I thought it was only needed if you did manual linking. So I encountered the same issue as this user:

https://github.com/agencyenterprise/react-native-health/issues/27

Updated the documentation to make this step clearer and also made a small syntax fix to the code in the doc.