### PR TITLE
FIX Typescript definition for getWeightSamples

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare module 'react-native-health' {
 
     getWeightSamples(
       options: HealthUnitOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     saveWeight(


### PR DESCRIPTION
Fix `results` type callback param for `getWeightSamples` it returns an array of object, not just an object.