### PR TITLE
feat: anchored object query for workouts

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.h
@@ -10,6 +10,7 @@
 
 @interface RCTAppleHealthKit (Methods_Workout)
 
+- (void)workout_getAnchoredQuery:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)workout_save: (NSDictionary *)input callback: (RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Workout.m
@@ -12,6 +12,39 @@
 
 @implementation RCTAppleHealthKit (Methods_Workout)
 
+- (void)workout_getAnchoredQuery:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    
+    HKSampleType *workoutType = [HKObjectType workoutType];
+    HKQueryAnchor *anchor = [RCTAppleHealthKit hkAnchorFromOptions:input];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    
+    NSPredicate *predicate = [RCTAppleHealthKit predicateForAnchoredQueries:anchor startDate:startDate endDate:endDate];
+
+    void (^completion)(NSDictionary *results, NSError *error);
+
+    completion = ^(NSDictionary *results, NSError *error) {
+        if (results){
+            callback(@[[NSNull null], results]);
+
+            return;
+        } else {
+            NSLog(@"error getting samples: %@", error);
+            callback(@[RCTMakeError(@"error getting samples", error, nil)]);
+
+            return;
+        }
+    };
+
+    [self fetchAnchoredWorkouts:workoutType
+                      predicate:predicate
+                         anchor:anchor
+                          limit:limit
+                     completion:completion];
+}
+
 - (void)workout_save: (NSDictionary *)input callback: (RCTResponseSenderBlock)callback {
     HKWorkoutActivityType type = [RCTAppleHealthKit hkWorkoutActivityTypeFromOptions:input key:@"type" withDefault:HKWorkoutActivityTypeAmericanFootball];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.h
@@ -37,6 +37,12 @@
                              limit:(NSUInteger)lim
                         completion:(void (^)(NSArray *, NSError *))completion;
 
+- (void)fetchAnchoredWorkouts:(HKSampleType *)type
+                    predicate:(NSPredicate *)predicate
+                       anchor:(HKQueryAnchor *)anchor
+                        limit:(NSUInteger)lim
+                   completion:(void (^)(NSDictionary *, NSError *))completion;
+
 - (void)fetchQuantitySamplesOfType:(HKQuantityType *)quantityType
                               unit:(HKUnit *)unit
                          predicate:(NSPredicate *)predicate

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -230,6 +230,93 @@
     [self.healthStore executeQuery:query];
 }
 
+- (void)fetchAnchoredWorkouts:(HKSampleType *)type
+                    predicate:(NSPredicate *)predicate
+                       anchor:(HKQueryAnchor *)anchor
+                        limit:(NSUInteger)lim
+                   completion:(void (^)(NSDictionary *, NSError *))completion {
+
+    // declare the block
+    void (^handlerBlock)(HKAnchoredObjectQuery *query, NSArray<__kindof HKSample *> *sampleObjects, NSArray<HKDeletedObject *> *deletedObjects, HKQueryAnchor *newAnchor, NSError *error);
+
+    // create and assign the block
+    handlerBlock = ^(HKAnchoredObjectQuery *query, NSArray<__kindof HKSample *> *sampleObjects, NSArray<HKDeletedObject *> *deletedObjects, HKQueryAnchor *newAnchor, NSError *error) {
+
+        if (!sampleObjects) {
+            if (completion) {
+                completion(nil, error);
+            }
+            return;
+        }
+
+        if (completion) {
+            NSMutableArray *data = [NSMutableArray arrayWithCapacity:1];
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                for (HKWorkout *sample in sampleObjects) {
+                    @try {
+                        double energy =  [[sample totalEnergyBurned] doubleValueForUnit:[HKUnit kilocalorieUnit]];
+                        double distance = [[sample totalDistance] doubleValueForUnit:[HKUnit mileUnit]];
+                        NSString *type = [RCTAppleHealthKit stringForHKWorkoutActivityType:[sample workoutActivityType]];
+
+                        NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
+                        NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
+
+                        bool isTracked = true;
+                        if ([[sample metadata][HKMetadataKeyWasUserEntered] intValue] == 1) {
+                            isTracked = false;
+                        }
+
+                        NSString* device = @"";
+                        if (@available(iOS 11.0, *)) {
+                            device = [[sample sourceRevision] productType];
+                        } else {
+                            device = [[sample device] name];
+                            if (!device) {
+                                device = @"iPhone";
+                            }
+                        }
+
+                        NSDictionary *elem = @{
+                                               @"activityId" : [NSNumber numberWithInt:[sample workoutActivityType]],
+                                               @"id" : [[sample UUID] UUIDString],
+                                               @"activityName" : type,
+                                               @"calories" : @(energy),
+                                               @"tracked" : @(isTracked),
+                                               @"metadata" : [sample metadata],
+                                               @"sourceName" : [[[sample sourceRevision] source] name],
+                                               @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
+                                               @"device": device,
+                                               @"distance" : @(distance),
+                                               @"start" : startDateString,
+                                               @"end" : endDateString
+                                               };
+
+                        [data addObject:elem];
+                    } @catch (NSException *exception) {
+                        NSLog(@"RNHealth: An error occured while trying to add workout sample: %@ ", [[[sample sourceRevision] source] bundleIdentifier]);
+                    }
+                }
+                
+                NSData *anchorData = [NSKeyedArchiver archivedDataWithRootObject:newAnchor];
+                NSString *anchorString = [anchorData base64EncodedStringWithOptions:0];
+                completion(@{
+                            @"anchor": anchorString,
+                            @"data": data,
+                        }, error);
+            });
+        }
+    };
+
+    HKAnchoredObjectQuery *query = [[HKAnchoredObjectQuery alloc] initWithType:type
+                                                                     predicate:predicate
+                                                                        anchor:anchor
+                                                                         limit:lim
+                                                                resultsHandler:handlerBlock];
+
+    [self.healthStore executeQuery:query];
+}
+
 - (void)fetchSleepCategorySamplesForPredicate:(NSPredicate *)predicate
                                         limit:(NSUInteger)lim
                                    completion:(void (^)(NSArray *, NSError *))completion {

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.h
@@ -16,6 +16,7 @@
 + (NSPredicate *)predicateForSamplesOnDay:(NSDate *)date;
 + (NSPredicate *)predicateForSamplesBetweenDates:(NSDate *)startDate endDate:(NSDate *)endDate;
 + (NSPredicate *)predicateForSamplesOnDayFromTimestamp:(NSString *)timestamp;
++ (NSPredicate *)predicateForAnchoredQueries:(HKQueryAnchor *)anchor startDate:(NSDate *)startDate endDate:(NSDate *)endDate;
 + (double)doubleValueFromOptions:(NSDictionary *)options;
 + (NSDate *)dateFromOptions:(NSDictionary *)options;
 + (NSDate *)dateFromOptionsDefaultNow:(NSDictionary *)options;
@@ -23,7 +24,7 @@
 + (NSDate *)endDateFromOptions:(NSDictionary *)options;
 + (NSDate *)endDateFromOptionsDefaultNow:(NSDictionary *)options;
 + (HKSampleType *)quantityTypeFromName:(NSString *)type;
-
++ (HKQueryAnchor *)hkAnchorFromOptions:(NSDictionary *)options;
 + (HKUnit *)hkUnitFromOptions:(NSDictionary *)options key:(NSString *)key withDefault:(HKUnit *)defaultValue;
 + (NSUInteger)uintFromOptions:(NSDictionary *)options key:(NSString *)key withDefault:(NSUInteger)defaultValue;
 + (double)doubleFromOptions:(NSDictionary *)options key:(NSString *)key withDefault:(double)defaultValue;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -57,6 +57,14 @@
     return [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
 }
 
++ (NSPredicate *)predicateForAnchoredQueries:(HKQueryAnchor *)anchor startDate:(NSDate *)startDate endDate:(NSDate *)endDate {
+    if (startDate == nil) {
+        return nil;
+    } else {
+        return [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
+    }
+
+}
 
 + (double)doubleValueFromOptions:(NSDictionary *)options {
     double value = [[options objectForKey:@"value"] doubleValue];
@@ -158,6 +166,17 @@
     }
 
     return [HKObjectType workoutType];
+}
+
++ (HKQueryAnchor *)hkAnchorFromOptions:(NSDictionary *)options {
+    NSString *anchorString = [options objectForKey:@"anchor"];
+    if (!anchorString.length) return nil;
+    NSData* anchorData = [[NSData alloc] initWithBase64EncodedString:anchorString options:0];
+    HKQueryAnchor *anchor = [NSKeyedUnarchiver unarchiveObjectWithData:anchorData];
+    if(anchor == nil){
+        return nil;
+    }
+    return anchor;
 }
 
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -166,6 +166,12 @@ RCT_EXPORT_METHOD(getSamples:(NSDictionary *)input callback:(RCTResponseSenderBl
     [self fitness_getSamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getAnchoredWorkouts:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self workout_getAnchoredQuery:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(setObserver:(NSDictionary *)input)
 {
     [self _initializeHealthStore];

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ they are splitted in the following categories
 #### Workout Methods
 
 - [getSamples](docs/getSamples.md)
+- [getAnchoredWorkouts](/docs/getAnchoredWorkouts.md)
 - [saveWorkout](/docs/saveWorkout.md)
 
 ## Additional Information

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,5 +101,5 @@ There is a gitbook version for the documentation on this [link](https://vinicius
 
 #### Workout Methods
 
-- [getWorkout](getWorkout.md)
+- [getAnchoredWorkouts](getAnchoredWorkouts.md)
 - [saveWorkout](saveWorkout.md)

--- a/docs/getAnchoredWorkouts.md
+++ b/docs/getAnchoredWorkouts.md
@@ -1,0 +1,63 @@
+# getAnchoredWorkouts Query
+
+Query to get all workouts of any given type by a given anchor (a physical memory address) OR for a specific date range. If succesful, this method will return an object that contains all of the workouts for that specific query and a new anchor for subsequent calls. Workouts returned are unsorted. 
+
+## Params:
+
+- If the startDate is *nil*, the getAnchoredQuery will return *ALL* available workouts, as well as the base64 encoded anchor.
+
+- If both a stardDate and endDate are provided but without an anchor, results will be an array of unsorted workouts from that range and as well as a base64 encoded anchor (the last workout). 
+
+- If an anchor is provided along with a startDate and endDate, and the resulting workouts will be of any additions after the anchor (provided they are within the range of that date). 
+
+- If an anchor is provided but without a time range. Thus, if the anchor points to a workout done today, but the user adds a workout in Apple Health that happens 2 years ago, the query will return that workout since it was added to healthkit after the anchor provided.
+
+```ts
+let options = {
+  startDate?: (new Date(2016,4,27)).toISOString(), // 
+  endDate?: (new Date()).toISOString(),
+  queryAnchor?: 'base64encodedstring',
+  type: 'Workout', // one of: ['Walking', 'StairClimbing', 'Running', 'Cycling', 'Workout']
+};
+```
+
+## Response
+
+If an anchor was given, all of the entries added after that anchor will be returned, regardless of date. The resulting response of this query will look as following:
+
+```ts
+interface AnchoredQueryResults {
+    anchor: string
+    data: Array<HKWorkoutQueriedSampleType>
+  }
+```
+
+The callback function will be called with a `samples` array containing objects with *value*, *queryAnchor*, *startDate*, and *endDate* fields
+
+```ts
+AppleHealthKit.getAnchoredWorkouts(options, (err: Object, results: AnchoredQueryResults) => {
+  if (err) {
+    return;
+  }
+  console.log(results.data)
+  console.log(results.anchor)
+});
+```
+
+The resulting workouts in the array will look as the following:
+
+```ts
+{
+  activityId: Number, // [NSNumber numberWithInt:[sample workoutActivityType]]
+  activityName: Number, // [RCTAppleHealthKit stringForHKWorkoutActivityType:[sample workoutActivityType]]
+  metadata: String, 
+  calories: Number, // [[sample totalEnergyBurned] doubleValueForUnit:[HKUnit kilocalorieUnit]]
+  tracked: Boolean, // [[sample metadata][HKMetadataKeyWasUserEntered] intValue] !== 1
+  sourceName: String, // [[[sample sourceRevision] source] name]
+  sourceId: String, // [[[sample sourceRevision] source] bundleIdentifier]
+  device: String, // [[sample sourceRevision] productType] or 'iPhone'
+  distance: Number, // [[sample totalDistance] doubleValueForUnit:[HKUnit mileUnit]]
+  start: String, // [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
+  end: String, // [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
+}
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,11 @@ declare module 'react-native-health' {
       callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
+    getAnchoredWorkouts(
+      options: HealthInputOptions,
+      callback: (err: string, results: AnchoredQueryResults) => void,
+    ): void
+
     getDailyStepCountSamples(
       options: HealthInputOptions,
       callback: (err: string, results: Array<HealthValue>) => void,
@@ -347,8 +352,24 @@ declare module 'react-native-health' {
     date?: string
     includeManuallyAdded?: boolean
     period?: number
+    anchor?: string;
   }
 
+  export interface HKWorkoutQueriedSampleType {
+    activityId: number
+    activityName: string
+    calories: number
+    device: string
+    id: string
+    tracked: string
+    metadata: any
+    sourceName: string
+    sourceId: string
+    distance: number
+    start: string
+    end: string
+  }
+  
   export interface HealthValueOptions extends HealthUnitOptions {
     value: number
     startDate?: string
@@ -557,6 +578,11 @@ declare module 'react-native-health' {
       read: HealthStatusCode[]
       write: HealthStatusCode[]
     }
+  }
+
+  export interface AnchoredQueryResults {
+    anchor: string,
+    data: Array<HKWorkoutQueriedSampleType>,
   }
 
   export enum HealthObserver {


### PR DESCRIPTION
## Description

feat(anchored-workout-query): create a workouts query using an hkanchoredobjectquery

* Adds a library method that allows to query workouts via an HKAnchoredObjectQuery, exposing a query workouts results array and a resulting base-64 encoded anchor to the react-native bridge
* Adds utility methods to create an anchored query predicate with optional base-64 encoded anchor, startDate, and endDate params
* Adds documentations, as well as typescript definitions
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
