### PR TITLE
feat: introduce `getBloodType` method

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.h
@@ -12,5 +12,6 @@
 
 - (void)characteristic_getBiologicalSex:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)characteristic_getDateOfBirth:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)characteristic_getBloodType:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
@@ -76,4 +76,51 @@
     callback(@[[NSNull null], response]);
 }
 
+- (void)characteristic_getBloodType:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback {
+    NSError *error;
+    HKBloodTypeObject *bioBlood = [self.healthStore bloodTypeWithError:&error];
+    NSString *value;
+
+    switch (bioBlood.bloodType) {
+        case HKBloodTypeNotSet:
+            value = @"unknown";
+            break;
+        case HKBloodTypeAPositive:
+            value = @"A+";
+            break;
+        case HKBloodTypeANegative:
+            value = @"A-";
+            break;
+        case HKBloodTypeBPositive:
+            value = @"B+";
+            break;
+        case HKBloodTypeBNegative:
+            value = @"B-";
+            break;
+        case HKBloodTypeABPositive:
+            value = @"AB+";
+            break;
+        case HKBloodTypeABNegative:
+            value = @"AB-";
+            break;
+        case HKBloodTypeOPositive:
+            value = @"O+";
+            break;
+        case HKBloodTypeONegative:
+            value = @"O-";
+            break;
+    }
+
+    if(value == nil){
+        callback(@[RCTJSErrorFromNSError(error)]);
+        return;
+    }
+
+    NSDictionary *response = @{
+            @"value" : value,
+    };
+
+    callback(@[[NSNull null], response]);
+}
+
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -25,6 +25,8 @@
         return [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierDateOfBirth];
     } else if ([@"BiologicalSex" isEqualToString: key]) {
         return [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBiologicalSex];
+    } else if ([@"BloodType" isEqualToString: key]) {
+        return [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBloodType];
     }
 
     // Body Measurements

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -50,6 +50,11 @@ RCT_EXPORT_METHOD(getBiologicalSex:(NSDictionary *)input callback:(RCTResponseSe
     [self characteristic_getBiologicalSex:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getBloodType:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self characteristic_getBloodType:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getDateOfBirth:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self characteristic_getDateOfBirth:input callback:callback];

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@
 ### Characteristic Methods
 
 - [getBiologicalSex](getBiologicalSex.md)
+- [getBloodType](getBloodType.md)
 - [getDateOfBirth](getDateOfBirth.md)
 
 ### Dietary Methods

--- a/docs/getBloodType.md
+++ b/docs/getBloodType.md
@@ -1,0 +1,32 @@
+# getBloodType
+
+Get the blood type. If the `BloodType` read permission is missing or the user has denied it then the value will be `unknown`. The possible values are:
+
+| Value   | HKBiologicalSex       |
+| ------- | --------------------- |
+| unknown | HKBloodTypeNotSet     |
+| A+      | HKBloodTypeAPositive  |
+| A-      | HKBloodTypeANegative  |
+| B+      | HKBloodTypeBPositive  |
+| B-      | HKBloodTypeBNegative  |
+| AB+     | HKBloodTypeABPositive |
+| AB-     | HKBloodTypeABNegative |
+| O+      | HKBloodTypeOPositive  |
+| O+      | HKBloodTypeONegative  |
+
+```javascript
+AppleHealthKit.getBloodType(null, (err: Object, results: Object) => {
+  if (err) {
+    return
+  }
+  console.log(results)
+})
+```
+
+Example output:
+
+```json
+{
+  "value": "A-"
+}
+```

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -107,7 +107,7 @@ The available Healthkit identifiers are supported
 | ActiveEnergyBurned     | [HKQuantityTypeIdentifierActiveEnergyBurned](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615771-activeenergyburned?language=objc) | ✓    |       |
 | BasalEnergyBurned      | [HKQuantityTypeIdentifierBasalEnergyBurned](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615512-basalenergyburned?language=objc)   | ✓    |       |
 | BiologicalSex          | [HKCharacteristicTypeIdentifierBiologicalSex](https://developer.apple.com/reference/Healthkit/hkcharacteristictypeidentifierbiologicalsex?language=objc)            | ✓    |       |
-| BloodType    | [HKCharacteristicTypeIdentifierBloodType](https://developer.apple.com/documentation/healthkit/hkcharacteristictypeidentifierbloodtype?language=objc)            | ✓    | ✓     |
+| BloodType    | [HKCharacteristicTypeIdentifierBloodType](https://developer.apple.com/documentation/healthkit/hkcharacteristictypeidentifierbloodtype?language=objc)            | ✓    |     |
 | BloodAlcoholContent    | [HKQuantityTypeIdentifierBloodAlcoholContent](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierbloodalcoholcontent?language=objc)            | ✓    | ✓     |
 | BloodGlucose           | [HKQuantityTypeIdentifierBloodGlucose](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierbloodglucose?language=objc)                          | ✓    |       |
 | BloodPressureDiastolic | [HKQuantityTypeIdentifierBloodPressureDiastolic](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierbloodpressurediastolic?language=objc)  | ✓    | ✓     |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -30,6 +30,7 @@ AppleHealthKit.initHealthKit(permissions, (error: string) => {
   AppleStandTime
   BasalEnergyBurned
   BiologicalSex
+  BloodType
   BloodAlcoholContent
   BloodGlucose
   BloodPressureDiastolic
@@ -106,6 +107,7 @@ The available Healthkit identifiers are supported
 | ActiveEnergyBurned     | [HKQuantityTypeIdentifierActiveEnergyBurned](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615771-activeenergyburned?language=objc) | ✓    |       |
 | BasalEnergyBurned      | [HKQuantityTypeIdentifierBasalEnergyBurned](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/1615512-basalenergyburned?language=objc)   | ✓    |       |
 | BiologicalSex          | [HKCharacteristicTypeIdentifierBiologicalSex](https://developer.apple.com/reference/Healthkit/hkcharacteristictypeidentifierbiologicalsex?language=objc)            | ✓    |       |
+| BloodType    | [HKCharacteristicTypeIdentifierBloodType](https://developer.apple.com/documentation/healthkit/hkcharacteristictypeidentifierbloodtype?language=objc)            | ✓    | ✓     |
 | BloodAlcoholContent    | [HKQuantityTypeIdentifierBloodAlcoholContent](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierbloodalcoholcontent?language=objc)            | ✓    | ✓     |
 | BloodGlucose           | [HKQuantityTypeIdentifierBloodGlucose](https://developer.apple.com/reference/Healthkit/hkquantitytypeidentifierbloodglucose?language=objc)                          | ✓    |       |
 | BloodPressureDiastolic | [HKQuantityTypeIdentifierBloodPressureDiastolic](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierbloodpressurediastolic?language=objc)  | ✓    | ✓     |

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,11 @@ declare module 'react-native-health' {
       callback: (err: string, results: HealthValue) => void,
     ): void
 
+    getBloodType(
+      options: HealthUnitOptions,
+      callback: (err: string, results: HealthValue) => void,
+    ): void
+
     getDateOfBirth(
       options: any,
       callback: (err: string, results: HealthDateOfBirth) => void,
@@ -443,6 +448,7 @@ declare module 'react-native-health' {
     AppleStandTime = 'AppleStandTime',
     BasalEnergyBurned = 'BasalEnergyBurned',
     BiologicalSex = 'BiologicalSex',
+    BloodType = 'BloodType',
     BloodAlcoholContent = 'BloodAlcoholContent',
     BloodGlucose = 'BloodGlucose',
     BloodPressureDiastolic = 'BloodPressureDiastolic',

--- a/src/constants/Permissions.js
+++ b/src/constants/Permissions.js
@@ -9,6 +9,7 @@ export const Permissions = {
   AppleStandTime: 'AppleStandTime',
   BasalEnergyBurned: 'BasalEnergyBurned',
   BiologicalSex: 'BiologicalSex',
+  BloodType: 'BloodType',
   BloodAlcoholContent: 'BloodAlcoholContent',
   BloodGlucose: 'BloodGlucose',
   BloodPressureDiastolic: 'BloodPressureDiastolic',


### PR DESCRIPTION
## Description

That PR introduces `getBloodType` method, according to [Apple documentation](https://developer.apple.com/documentation/healthkit/hkbloodtype). Also PR adds the new permission called `BloodType` to have an option to obtain the blood type.

Permission | Result
--- | ---
<img width="300" alt="Zrzut ekranu 2021-04-1 o 12 28 50" src="https://user-images.githubusercontent.com/22746080/113281436-d5f98e00-92e5-11eb-99da-f83f380ac725.png"> | <img src="https://user-images.githubusercontent.com/22746080/113281967-9bdcbc00-92e6-11eb-94ae-1891fc7ac5d0.gif" width="300" />




## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
