### PR TITLE
Add methods for reading Dietary: Energy Consumed and Dietary: Protein

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.h
@@ -12,5 +12,7 @@
 
 - (void)saveFood:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)saveWater:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)dietary_getEnergyConsumedSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)dietary_getProteinSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.m
@@ -15,6 +15,68 @@
 
 @implementation RCTAppleHealthKit (Methods_Dietary)
 
+- (void)dietary_getEnergyConsumedSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *energyConsumedType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryEnergyConsumed];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit kilocalorieUnit]];
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+    NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+
+    [self fetchQuantitySamplesOfType:energyConsumedType
+                                unit:unit
+                           predicate:predicate
+                           ascending:ascending
+                               limit:limit
+                          completion:^(NSArray *results, NSError *error) {
+        if(results){
+            callback(@[[NSNull null], results]);
+            return;
+        } else {
+            NSLog(@"An error occured while retrieving the energy consumed sample %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while retrieving the energy consumed sample", error, nil)]);
+            return;
+        }
+    }];
+}
+
+- (void)dietary_getProteinSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *proteinType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryProtein];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit gramUnit]];
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+    NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+
+    [self fetchQuantitySamplesOfType:proteinType
+                                unit:unit
+                           predicate:predicate
+                           ascending:ascending
+                               limit:limit
+                          completion:^(NSArray *results, NSError *error) {
+        if(results){
+            callback(@[[NSNull null], results]);
+            return;
+        } else {
+            NSLog(@"An error occured while retrieving the protein sample %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while retrieving the protein sample", error, nil)]);
+            return;
+        }
+    }];
+}
+
 - (void)saveFood:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     NSString *foodNameValue = [RCTAppleHealthKit stringFromOptions:input key:@"foodName" withDefault:nil];
@@ -57,13 +119,13 @@
     double vitaminEValue = [RCTAppleHealthKit doubleFromOptions:input key:@"vitaminE" withDefault:(double)0];
     double vitaminKValue = [RCTAppleHealthKit doubleFromOptions:input key:@"vitaminK" withDefault:(double)0];
     double zincValue = [RCTAppleHealthKit doubleFromOptions:input key:@"zinc" withDefault:(double)0];
-    
+
     // Metadata including some new food-related keys //
     NSDictionary *metadata = @{
             HKMetadataKeyFoodType:foodNameValue,
             //@"HKFoodBrandName":@"FoodBrandName", // Restaurant name or packaged food brand name
             //@"HKFoodTypeUUID":@"FoodTypeUUID", // Identifier for this food
-            @"HKFoodMeal":mealNameValue//, // Breakfast, Lunch, Dinner, or Snacks 
+            @"HKFoodMeal":mealNameValue//, // Breakfast, Lunch, Dinner, or Snacks
             //@"HKFoodImageName":@"FoodImageName" // Food icon name
     };
 
@@ -348,7 +410,7 @@
                                                                     startDate:timeFoodWasConsumed
                                                                         endDate:timeFoodWasConsumed
                                                                     metadata:metadata];
-    
+
         [mySet addObject:vitaminE];
     }
     if (vitaminKValue > 0){

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -195,6 +195,17 @@ RCT_EXPORT_METHOD(getDailyFlightsClimbedSamples:(NSDictionary *)input callback:(
     [self fitness_getDailyFlightsClimbedSamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getEnergyConsumedSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+   [self dietary_getEnergyConsumedSamples:input callback:callback];
+}
+
+RCT_EXPORT_METHOD(getProteinSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+   [self dietary_getProteinSamples:input callback:callback];
+}
+
+
 RCT_EXPORT_METHOD(saveFood:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self saveFood:input callback:callback];

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ they are splitted in the following categories
 
 ### Dietary Methods
 
+- [getEnergyConsumedSamples](/docs/getEnergyConsumedSamples.md)
+- [getProteinSamples](/docs/getProteinSamples.md)
 - [saveFood](/docs/saveFood.md)
 - [saveWater](/docs/saveWater.md)
 

--- a/docs/getEnergyConsumedSamples.md
+++ b/docs/getEnergyConsumedSamples.md
@@ -1,0 +1,42 @@
+# getEnergyConsumedSamples
+
+A quantity sample type that measures the amount of energy consumed.
+
+Permission required:
+
+- `AppleHealthKit.Constants.Permissions.EnergyConsumed`
+
+Example input options:
+
+```javascript
+let options = {
+  startDate: new Date(2021, 0, 0).toISOString(), // required
+  endDate: new Date().toISOString(), // optional; default now
+}
+```
+
+Call the method:
+
+```javascript
+AppleHealthKit.getEnergyConsumedSamples(
+  (options: HealthInputOptions),
+  (err: Object, results: HealthValue) => {
+    if (err) {
+      return
+    }
+    console.log(results)
+  },
+)
+```
+
+Example output:
+
+```json
+[
+  {
+    "endDate": "2021-04-01T22:00:00.000+0300", 
+    "startDate": "2021-04-01T22:00:00.000+0300", 
+    "value": 204.5
+  }
+]
+```

--- a/docs/getProteinSamples.md
+++ b/docs/getProteinSamples.md
@@ -1,0 +1,42 @@
+# getProteinSamples
+
+A quantity sample type that measures the amount of protein consumed.
+
+Permission required:
+
+- `AppleHealthKit.Constants.Permissions.Protein`
+
+Example input options:
+
+```javascript
+let options = {
+  startDate: new Date(2021, 0, 0).toISOString(), // required
+  endDate: new Date().toISOString(), // optional; default now
+}
+```
+
+Call the method:
+
+```javascript
+AppleHealthKit.getProteinSamples(
+  (options: HealthInputOptions),
+  (err: Object, results: HealthValue) => {
+    if (err) {
+      return
+    }
+    console.log(results)
+  },
+)
+```
+
+Example output:
+
+```json
+[
+  {
+    "endDate": "2021-04-01T22:00:00.000+0300", 
+    "startDate": "2021-04-01T22:00:00.000+0300", 
+    "value": 39
+  }
+]
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { HealthInputOptions } from "react-native-health"
+
 declare module 'react-native-health' {
   export interface HealthKitPermissions {
     permissions: {
@@ -132,6 +134,16 @@ declare module 'react-native-health' {
     ): void
 
     getDailyFlightsClimbedSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getEnergyConsumedSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getProteinSamples(
       options: HealthInputOptions,
       callback: (err: string, results: Array<HealthValue>) => void,
     ): void


### PR DESCRIPTION
## Description

Added methods for accessing samples with information about energy and protein consumed.

------

I would like to mention that I am relatively new to react native, I have never written a single line of code in Objective-C & this is the first native method that I export to react native. I basically copied what was made for `getCarbohydratesSamples()` and changed the same files like the [PR for adding another new feature reagarding Blood Type](https://github.com/agencyenterprise/react-native-health/commit/1d0c791a8ad8acfa31be9c7680baf9609322eeb7).

I decided to put those methods where `saveFood()` is already put: `RCTAppleHealthKit+Methods_Dietary`. In Apple's documentation Energy Consumed and Protein are both in "Dietary". However the existing `getCarbohydratesSamples()` method is in `RCTAppleHealthKit+Methods_Results.m`.

Please let me know if I have to move them.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings

----- 