### PR TITLE
Update getHeartRateVariabilitySamples.md

### DIFF
--- a/docs/getHeartRateVariabilitySamples.md
+++ b/docs/getHeartRateVariabilitySamples.md
@@ -6,7 +6,7 @@ Example input options:
 
 ```javascript
 let options = {
-  unit: 'bpm', // optional; default 'bpm'
+  unit: 'second', // optional; default 'second'
   startDate: new Date(2021, 0, 0).toISOString(), // required
   endDate: new Date().toISOString(), // optional; default now
   ascending: false, // optional; default false


### PR DESCRIPTION
Fixed units documentation for HRV: Apple Health returns it in seconds (which you can then convert to ms), not bpm.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixed units documentation for HRV: Apple Health returns it in seconds (which you can then convert to ms), not bpm. Was initially confusing seeing the HRV values returned in decimals, and thought it was somehow being converted to bpm, as most developers would expect it in milliseconds.

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
