### PR TITLE
fix: error handling for malformed items in getSamples

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -137,82 +137,92 @@
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (type == [HKObjectType workoutType]) {
                     for (HKWorkout *sample in results) {
-                        double energy =  [[sample totalEnergyBurned] doubleValueForUnit:[HKUnit kilocalorieUnit]];
-                        double distance = [[sample totalDistance] doubleValueForUnit:[HKUnit mileUnit]];
-                        NSString *type = [RCTAppleHealthKit stringForHKWorkoutActivityType:[sample workoutActivityType]];
+                        @try {
+                            double energy =  [[sample totalEnergyBurned] doubleValueForUnit:[HKUnit kilocalorieUnit]];
+                            double distance = [[sample totalDistance] doubleValueForUnit:[HKUnit mileUnit]];
+                            NSString *type = [RCTAppleHealthKit stringForHKWorkoutActivityType:[sample workoutActivityType]];
 
-                        NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
-                        NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
+                            NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
+                            NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
 
-                        bool isTracked = true;
-                        if ([[sample metadata][HKMetadataKeyWasUserEntered] intValue] == 1) {
-                            isTracked = false;
-                        }
-
-                        NSString* device = @"";
-                        if (@available(iOS 11.0, *)) {
-                            device = [[sample sourceRevision] productType];
-                        } else {
-                            device = [[sample device] name];
-                            if (!device) {
-                                device = @"iPhone";
+                            bool isTracked = true;
+                            if ([[sample metadata][HKMetadataKeyWasUserEntered] intValue] == 1) {
+                                isTracked = false;
                             }
+
+                            NSString* device = @"";
+                            if (@available(iOS 11.0, *)) {
+                                device = [[sample sourceRevision] productType];
+                            } else {
+                                device = [[sample device] name];
+                                if (!device) {
+                                    device = @"iPhone";
+                                }
+                            }
+
+                            NSDictionary *elem = @{
+                                                   @"activityId" : [NSNumber numberWithInt:[sample workoutActivityType]],
+                                                   @"id" : [[sample UUID] UUIDString],
+                                                   @"activityName" : type,
+                                                   @"calories" : @(energy),
+                                                   @"tracked" : @(isTracked),
+                                                   @"metadata" : [sample metadata],
+                                                   @"sourceName" : [[[sample sourceRevision] source] name],
+                                                   @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
+                                                   @"device": device,
+                                                   @"distance" : @(distance),
+                                                   @"start" : startDateString,
+                                                   @"end" : endDateString
+                                                   };
+
+                            [data addObject:elem];
+                        } @catch (NSException *exception) {
+                            NSLog(@"RNHealth: An error occured while trying to add sample from: %@ ", [[[sample sourceRevision] source] bundleIdentifier]);
                         }
-
-                        NSDictionary *elem = @{
-                                               @"activityId" : [NSNumber numberWithInt:[sample workoutActivityType]],
-                                               @"activityName" : type,
-                                               @"calories" : @(energy),
-                                               @"tracked" : @(isTracked),
-                                               @"sourceName" : [[[sample sourceRevision] source] name],
-                                               @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
-                                               @"device": device,
-                                               @"distance" : @(distance),
-                                               @"start" : startDateString,
-                                               @"end" : endDateString
-                                               };
-
-                        [data addObject:elem];
                     }
                 } else {
                     for (HKQuantitySample *sample in results) {
-                        HKQuantity *quantity = sample.quantity;
-                        double value = [quantity doubleValueForUnit:unit];
+                        @try {
+                            HKQuantity *quantity = sample.quantity;
+                            double value = [quantity doubleValueForUnit:unit];
 
-                        NSString * valueType = @"quantity";
-                        if (unit == [HKUnit mileUnit]) {
-                            valueType = @"distance";
-                        }
-
-                        NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
-                        NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
-
-                        bool isTracked = true;
-                        if ([[sample metadata][HKMetadataKeyWasUserEntered] intValue] == 1) {
-                            isTracked = false;
-                        }
-
-                        NSString* device = @"";
-                        if (@available(iOS 11.0, *)) {
-                            device = [[sample sourceRevision] productType];
-                        } else {
-                            device = [[sample device] name];
-                            if (!device) {
-                                device = @"iPhone";
+                            NSString * valueType = @"quantity";
+                            if (unit == [HKUnit mileUnit]) {
+                                valueType = @"distance";
                             }
+
+                            NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
+                            NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
+
+                            bool isTracked = true;
+                            if ([[sample metadata][HKMetadataKeyWasUserEntered] intValue] == 1) {
+                                isTracked = false;
+                            }
+
+                            NSString* device = @"";
+                            if (@available(iOS 11.0, *)) {
+                                device = [[sample sourceRevision] productType];
+                            } else {
+                                device = [[sample device] name];
+                                if (!device) {
+                                    device = @"iPhone";
+                                }
+                            }
+
+                            NSDictionary *elem = @{
+                                                   valueType : @(value),
+                                                   @"tracked" : @(isTracked),
+                                                   @"sourceName" : [[[sample sourceRevision] source] name],
+                                                   @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
+                                                   @"device": device,
+                                                   @"start" : startDateString,
+                                                   @"end" : endDateString
+                                                   };
+
+                            [data addObject:elem];
+                        } @catch (NSException *exception) {
+                            NSLog(@"RNHealth: An error occured while trying to add sample from: %@ ", [[[sample sourceRevision] source] bundleIdentifier]);
                         }
-
-                        NSDictionary *elem = @{
-                                               valueType : @(value),
-                                               @"tracked" : @(isTracked),
-                                               @"sourceName" : [[[sample sourceRevision] source] name],
-                                               @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
-                                               @"device": device,
-                                               @"start" : startDateString,
-                                               @"end" : endDateString
-                                               };
-
-                        [data addObject:elem];
                     }
                 }
 
@@ -294,7 +304,7 @@
 
                         [data addObject:elem];
                     } @catch (NSException *exception) {
-                        NSLog(@"RNHealth: An error occured while trying to add workout sample: %@ ", [[[sample sourceRevision] source] bundleIdentifier]);
+                        NSLog(@"RNHealth: An error occured while trying to add workout sample from: %@ ", [[[sample sourceRevision] source] bundleIdentifier]);
                     }
                 }
                 

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -15,21 +15,31 @@
 
 + (NSDate *)parseISO8601DateFromString:(NSString *)date
 {
-    NSDateFormatter *dateFormatter = [NSDateFormatter new];
-    NSLocale *posix = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-    dateFormatter.locale = posix;
-    dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ";
-    return [dateFormatter dateFromString:date];
+    @try {
+        NSDateFormatter *dateFormatter = [NSDateFormatter new];
+        NSLocale *posix = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        dateFormatter.locale = posix;
+        dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ";
+        return [dateFormatter dateFromString:date];
+    } @catch (NSException *exception) {
+        NSLog(@"RNHealth: An error occured while trying parse ISO8601 date from string");
+        return nil;
+    }
 }
 
 
 + (NSString *)buildISO8601StringFromDate:(NSDate *)date
 {
-    NSDateFormatter *dateFormatter = [NSDateFormatter new];
-    NSLocale *posix = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-    dateFormatter.locale = posix;
-    dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ";
-    return [dateFormatter stringFromDate:date];
+    @try {
+        NSDateFormatter *dateFormatter = [NSDateFormatter new];
+        NSLocale *posix = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        dateFormatter.locale = posix;
+        dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ";
+        return [dateFormatter stringFromDate:date];
+    } @catch (NSException *exception) {
+        NSLog(@"RNHealth: An error occured while trying parse ISO8601 string from date");
+        return nil;
+    }   
 }
 
 


### PR DESCRIPTION
## Description

While querying getSamples, elements of type `HKWorkout` and `HKQuantity` with malformed properties can crash client app with vague error `{"message":"error getting samples"}`. This is particularly related to properties such as `Dates`. Thus as an extra safety, we've included a try catch statement in the dates utils method.

With this PR, we can at least catch sample sourceId in logs, without crashing client app.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
