### PR TITLE
fix(types): `tracked` should be a boolean

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -373,7 +373,7 @@ declare module 'react-native-health' {
     calories: number
     device: string
     id: string
-    tracked: string
+    tracked: boolean
     metadata: any
     sourceName: string
     sourceId: string


### PR DESCRIPTION
## Description

Sample `HKWorkoutQueriedSampleType` data, result of `getSamples()` with `type: 'Workout'`:

```js
[
  {
    activityId: 37,
    activityName: "Running",
    calories: 0,
    device: "iPhone12,1",
    distance: 0,
    end: "2021-04-19T20:43:00.000+0800",
    id: "7DC009CC-3B9A-4C14-B9FA-1D3880D1F07C",
    metadata: { HKWasUserEntered: 1 },
    sourceId: "com.apple.Health",
    sourceName: "Health",
    start: "2021-04-19T18:43:00.000+0800",
    tracked: false,
  },
]
```

Note `tracked` is a boolean.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
