### PR TITLE
adding interface for bloodpressure samples

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,10 +7,6 @@ declare module 'react-native-health' {
       write: HealthPermission[]
     }
   }
-  export interface BloodPressureSamples extends HealthValue {
-    bloodPressureSystolicValue: number
-    bloodPressureDiastolicValue: number,
-  }
 
   export interface Constants {
     Activities: Record<HealthActivity, HealthActivity>
@@ -224,7 +220,7 @@ declare module 'react-native-health' {
 
     getBloodPressureSamples(
       options: HealthInputOptions,
-      callback: (err: string, results: Array<BloodPressureSamples>) => void,
+      callback: (err: string, results: Array<BloodPressureSampleValue>) => void,
     ): void
 
     getRespiratoryRateSamples(
@@ -353,6 +349,11 @@ declare module 'react-native-health' {
     value: number
     startDate: string
     endDate: string
+  }
+
+  export interface BloodPressureSampleValue extends HealthValue {
+    bloodPressureSystolicValue: number
+    bloodPressureDiastolicValue: number
   }
 
   export interface HealthUnitOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,10 @@ declare module 'react-native-health' {
       write: HealthPermission[]
     }
   }
+  export interface BloodPressureSamples extends HealthValue {
+    bloodPressureSystolicValue: number
+    bloodPressureDiastolicValue: number,
+  }
 
   export interface Constants {
     Activities: Record<HealthActivity, HealthActivity>
@@ -220,7 +224,7 @@ declare module 'react-native-health' {
 
     getBloodPressureSamples(
       options: HealthInputOptions,
-      callback: (err: string, results: Array<HealthValue>) => void,
+      callback: (err: string, results: Array<BloodPressureSamples>) => void,
     ): void
 
     getRespiratoryRateSamples(


### PR DESCRIPTION
## Description

Just changed to type of `getBloodPressureSamples` to the corresponding one in the documentation (https://github.com/agencyenterprise/react-native-health/blob/master/docs/getBloodPressureSamples.md).
Here the value for `bloodPressureDiastolicValue` and `bloodPressureSystolicValue` is mentioned, but not listed as type, thus Typescript assumes it's wrong - yet it is working.
I chose to create a new interface for BloodPressureSamples, since the blood pressure values are only used there and nowhere else.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
