### PR TITLE
Fix crash with blood glucose unit

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -81,17 +81,17 @@
 {
     HKQuantityType *bloodGlucoseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];
 
-    HKUnit *mmoLPerL = [[HKUnit moleUnitWithMetricPrefix:HKMetricPrefixMilli molarMass:HKUnitMolarMassBloodGlucose] unitDividedByUnit:[HKUnit literUnit]];
-
     HKUnit *mgPerdL = [[HKUnit gramUnitWithMetricPrefix:HKMetricPrefixMilli] unitDividedByUnit:[HKUnit literUnitWithMetricPrefix:HKMetricPrefixDeci]];
 
     double value = [RCTAppleHealthKit doubleValueFromOptions:input];
     NSDate *sampleDate = [RCTAppleHealthKit dateFromOptions:input key:@"date" withDefault:[NSDate date]];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:sampleDate];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:sampleDate];
     HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:mgPerdL];
 
 
     HKQuantity *glucoseQuantity = [HKQuantity quantityWithUnit:unit doubleValue:value];
-    HKQuantitySample *glucoseSample = [HKQuantitySample quantitySampleWithType:bloodGlucoseType quantity:glucoseQuantity startDate:sampleDate endDate:sampleDate];
+    HKQuantitySample *glucoseSample = [HKQuantitySample quantitySampleWithType:bloodGlucoseType quantity:glucoseQuantity startDate:startDate endDate:endDate];
 
     [self.healthStore saveObject:glucoseSample withCompletion:^(BOOL success, NSError *error) {
         if (!success) {

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -16,13 +16,9 @@
 {
     HKQuantityType *bloodGlucoseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];
 
-    HKUnit *mmoLPerL = [[HKUnit moleUnitWithMetricPrefix:HKMetricPrefixMilli molarMass:HKUnitMolarMassBloodGlucose] unitDividedByUnit:[HKUnit literUnit]];
-    
     HKUnit *mgPerdL = [[HKUnit gramUnitWithMetricPrefix:HKMetricPrefixMilli] unitDividedByUnit:[HKUnit literUnitWithMetricPrefix:HKMetricPrefixDeci]];
 
-    
-
-    HKUnit *unit = [RCTAppleHealthKit stringFromOptions:input key:@"unit" withDefault:mgPerdL];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:mgPerdL];
     NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
     BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -16,9 +16,9 @@
 {
     HKQuantityType *bloodGlucoseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];
 
-    HKUnit *mgPerdL = [[HKUnit gramUnitWithMetricPrefix:HKMetricPrefixMilli] unitDividedByUnit:[HKUnit literUnitWithMetricPrefix:HKMetricPrefixDeci]];
+    HKUnit *mmolPerL = [[HKUnit moleUnitWithMetricPrefix:HKMetricPrefixMilli molarMass:HKUnitMolarMassBloodGlucose] unitDividedByUnit:[HKUnit literUnit]];
 
-    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:mgPerdL];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:mmolPerL];
     NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
     BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
@@ -81,13 +81,14 @@
 {
     HKQuantityType *bloodGlucoseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];
 
-    HKUnit *mgPerdL = [[HKUnit gramUnitWithMetricPrefix:HKMetricPrefixMilli] unitDividedByUnit:[HKUnit literUnitWithMetricPrefix:HKMetricPrefixDeci]];
+    HKUnit *mmolPerL = [[HKUnit moleUnitWithMetricPrefix:HKMetricPrefixMilli molarMass:HKUnitMolarMassBloodGlucose] unitDividedByUnit:[HKUnit literUnit]];
 
     double value = [RCTAppleHealthKit doubleValueFromOptions:input];
+    // Undocumented `date` property was used before, keeping for backwards compatibility.
     NSDate *sampleDate = [RCTAppleHealthKit dateFromOptions:input key:@"date" withDefault:[NSDate date]];
     NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:sampleDate];
-    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:sampleDate];
-    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:mgPerdL];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:startDate];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:mmolPerL];
 
 
     HKQuantity *glucoseQuantity = [HKQuantity quantityWithUnit:unit doubleValue:value];

--- a/docs/saveBloodGlucoseSample.md
+++ b/docs/saveBloodGlucoseSample.md
@@ -1,29 +1,33 @@
 # saveBloodGlucoseSample
 
-save a blood glucose value to Healthkit
+Save a blood glucose value to HealthKit.
 
-`saveBloodGlucoseSample` accepts an options object containing a percent value:
+`saveBloodGlucoseSample` accepts an options object containing glucose sample data and a callback:
 
-Example input options:
+Example input object:
 
 ```javascript
-let options = {
-    value: 16.7 // 16.7%
-    startDate: '2016-07-08T12:00:00.000-0400', // Optional, default now
-    unit: 'percent', // Optional, default is percent
+let input = {
+    value: 6.1, // 6.1 mmol/L
+    startDate: '2016-07-08T12:00:00.000-0400', // Optional, defaults to now
+    endDate: '2016-07-08T12:00:00.000-0400', // Optional, defaults to startDate
+    unit: 'mmolPerL', // Optional, defaults to mmolPerL
 }
 ```
 
-Call the method:
+Available units are: `'mmolPerL'`, `'mgPerdL'`.
+
+Example usage:
 
 ```javascript
 AppleHealthKit.saveBloodGlucoseSample(
-  (options: HealthInputOptions),
-  (err: Object, results: number) => {
+  input,
+  (err: Object, result: number) => {
     if (err) {
       return
     }
     // blood glucose successfully saved
+    console.log(result)
   },
 )
 ```
@@ -31,5 +35,5 @@ AppleHealthKit.saveBloodGlucoseSample(
 Example output:
 
 ```json
-16.7
+6.1
 ```


### PR DESCRIPTION
## Description

1. Fixes a crash when adding a blood glucose sample with a valid unit specified.

It was fixed by using one of the existing unit parsing methods.

Before the unit string was being set instead of a `HKUnit` object, which would cause a crash, when one of the object's methods was called during conversion.

2. Mapped the documented (but missing) `startDate` and `endDate` options with fallback to the undocumented `date` options, when saving a blood glucose sample.

3. Removed unused `mmoLPerL` variables.

Fixes # (new issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (N/A)
- [x] I have checked my code and corrected any misspellings
