### PR TITLE
Add units parameters to saveWorkout docs

### DIFF
--- a/docs/saveWorkout.md
+++ b/docs/saveWorkout.md
@@ -11,8 +11,10 @@ let options = {
   type: 'AmericanFootball', // See HealthActivity Enum
   startDate: new Date(2016, 6, 2, 6, 0, 0).toISOString(),
   endDate: new Date(2020, 6, 2, 6, 30, 0).toISOString(),
-  energyBurned: 50, // In Energy burned unit
+  energyBurned: 50, // In Energy burned unit,
+  energyBurnedUnit: 'calorie', 
   distance: 50, // In Distance unit
+  distanceUnit: 'meter'
 }
 ```
 


### PR DESCRIPTION
## Description

Update documentation for `saveWorkout` with required parameters for saving `totalEnergyBurned` and `totalDistance` for a workout.

Fixes #92 

## Type of change

- [x] Updating documentation
