### PR TITLE
Created Expo config plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ To add Healthkit support to your application's `Capabilities`
 - Select the project name in the left sidebar
 - In the main view select '+ Capability' and double click 'HealthKit'
 
+> 🚨 Expo: This package is not available in the [Expo Go](https://expo.io/client) app. Learn how you can use it with [custom dev clients](/docs/Expo.md).
+
 ## Usage
 
 In order to start collecting or saving data to HealthKit, you need to request

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A React Native package to interact with Apple HealthKit for iOS.
 
 ## Getting Started
 
+> 🚨 Expo: This package is not available in the [Expo Go](https://expo.io/client) app. Learn how you can use it with [custom dev clients](/docs/Expo.md).
+
 ### Automatic Installation
 
 1. Install the react-native-health package from [npm](https://www.npmjs.com/package/react-native-health)
@@ -41,8 +43,6 @@ To add Healthkit support to your application's `Capabilities`
 - Open the `ios/` folder of your project in Xcode
 - Select the project name in the left sidebar
 - In the main view select '+ Capability' and double click 'HealthKit'
-
-> 🚨 Expo: This package is not available in the [Expo Go](https://expo.io/client) app. Learn how you can use it with [custom dev clients](/docs/Expo.md).
 
 ## Usage
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,49 @@
+const { withEntitlementsPlist, withInfoPlist } = require('@expo/config-plugins')
+
+const HEALTH_SHARE = 'Allow $(PRODUCT_NAME) to check health info'
+const HEALTH_UPDATE = 'Allow $(PRODUCT_NAME) to update health info'
+
+const withHealthKit = (
+  config,
+  { healthSharePermission, healthUpdatePermission, isClinicalDataEnabled } = {},
+) => {
+  // Add permissions
+  config = withInfoPlist(config, (config) => {
+    config.modResults.NSHealthShareUsageDescription =
+      healthSharePermission ||
+      config.modResults.NSHealthShareUsageDescription ||
+      HEALTH_SHARE
+    config.modResults.NSHealthUpdateUsageDescription =
+      healthUpdatePermission ||
+      config.modResults.NSHealthUpdateUsageDescription ||
+      HEALTH_UPDATE
+
+    return config
+  })
+
+  // Add entitlements. These are automatically synced when using EAS build for production apps.
+  config = withEntitlementsPlist(config, (config) => {
+    config.modResults['com.apple.developer.healthkit'] = true
+    if (
+      !Array.isArray(config.modResults['com.apple.developer.healthkit.access'])
+    ) {
+      config.modResults['com.apple.developer.healthkit.access'] = []
+    }
+
+    if (isClinicalDataEnabled) {
+      config.modResults['com.apple.developer.healthkit.access'].push(
+        'health-records',
+      )
+
+      // Remove duplicates
+      config.modResults['com.apple.developer.healthkit.access'] = [
+        ...new Set(config.modResults['com.apple.developer.healthkit.access']),
+      ]
+    }
+
+    return config
+  })
+
+  return config
+}
+module.exports = withHealthKit

--- a/docs/Expo.md
+++ b/docs/Expo.md
@@ -1,7 +1,6 @@
 # Expo installation
 
-This package cannot be used in the [Expo Go](https://expo.io/client) app, but it can be used with custom managed apps.
-Just add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+> This package cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
 
 First install the package with yarn, npm, or [`expo install`](https://docs.expo.io/workflow/expo-cli/#expo-install).
 
@@ -9,7 +8,7 @@ First install the package with yarn, npm, or [`expo install`](https://docs.expo.
 expo install react-native-health
 ```
 
-Then add the prebuild [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+After installing this npm package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
 
 ```json
 {
@@ -19,15 +18,7 @@ Then add the prebuild [config plugin](https://docs.expo.io/guides/config-plugins
 }
 ```
 
-Then rebuild the native app:
-
-- Run `expo prebuild`
-  - This will apply the config plugin using [prebuilding](https://expo.fyi/prebuilding).
-- Rebuild the app
-  - `yarn android` -- Build on Android.
-  - `yarn ios` -- Build on iOS, this requires a MacOS computer (see [EAS build](https://docs.expo.io/build/introduction/) for more options).
-
-> If the project doesn't build correctly with `yarn ios` or `yarn android`, please file an issue and try setting the project up manually.
+Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
 ## API
 

--- a/docs/Expo.md
+++ b/docs/Expo.md
@@ -1,0 +1,68 @@
+# Expo installation
+
+This package cannot be used in the [Expo Go](https://expo.io/client) app, but it can be used with custom managed apps.
+Just add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+
+First install the package with yarn, npm, or [`expo install`](https://docs.expo.io/workflow/expo-cli/#expo-install).
+
+```sh
+expo install react-native-health
+```
+
+Then add the prebuild [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": ["react-native-health"]
+  }
+}
+```
+
+Then rebuild the native app:
+
+- Run `expo prebuild`
+  - This will apply the config plugin using [prebuilding](https://expo.fyi/prebuilding).
+- Rebuild the app
+  - `yarn android` -- Build on Android.
+  - `yarn ios` -- Build on iOS, this requires a MacOS computer (see [EAS build](https://docs.expo.io/build/introduction/) for more options).
+
+> If the project doesn't build correctly with `yarn ios` or `yarn android`, please file an issue and try setting the project up manually.
+
+## API
+
+The plugin provides props for extra customization. Every time you change the props or plugins, you'll need to rebuild (and `prebuild`) the native app. If no extra properties are added, defaults will be used.
+
+- `healthSharePermission` (_string_): Sets the iOS `NSHealthShareUsageDescription` permission message to the `Info.plist`. Defaults to `Allow $(PRODUCT_NAME) to check health info`.
+- `healthUpdatePermission` (_string_): Sets the iOS `NSHealthUpdateUsageDescription` permission message to the `Info.plist`. Defaults to `Allow $(PRODUCT_NAME) to update health info`.
+- `isClinicalDataEnabled` (_boolean_): Adds `health-records` to the `com.apple.developer.healthkit.access` entitlement in the iOS project. Defaults to false.
+
+`app.config.js`
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-health",
+        {
+          "isClinicalDataEnabled": true,
+          "healthSharePermission": "Custom health share permission",
+          "healthUpdatePermission": "Custom health update permission"
+        }
+      ]
+    ]
+  }
+}
+```
+
+## Background Processing
+
+Background processing is not currently supported by this plugin.
+
+## Capabilities
+
+This plugin will enable the iOS `com.apple.developer.healthkit` entitlement, but in order to sync this with the bundle identifier' production capabilities you'll need to do one of two things:
+
+- Automatic: Build the app with [EAS build](https://docs.expo.io/build/introduction/)
+- Manual: Visit [Apple developer portal](https://developer.apple.com/account/resources/identifiers/list) and enable the HealthKit capability for your bundle identifier before building for production. This can also be done via Xcode.

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "peerDependencies": {
     "react-native": ">=0.40.0"
+  },
+  "dependencies": {
+    "@expo/config-plugins": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Description


With Expo SDK 41 we've rolled out an interface called [config plugins](https://docs.expo.io/guides/config-plugins/) which lets users add native modules that aren't in the Expo Go app to their native cloud builds and locally when [prebuilding](https://expo.fyi/prebuilding).

This is a [highly requested package](https://expo.canny.io/feature-requests/p/apple-healthkitgoogle-fit-data) so I've created the plugin personally.

## How 

Created a prebuild config plugin in `app.plugin.js`. Added a detailed docs page on how to use the plugin and the limitations.


## Test Plan

- Run `npm pack` in the package
- Install the package in a managed Expo project `yarn add react-native-health@../react-native-health/react-native-health-1.7.2.tgz`
- Then add `react-native-health` to the plugins array and build the native app locally with `expo prebuild` and `yarn ios`, `yarn android`. We plan to further automate these steps with `expo install` and `expo run` commands.
- App built correctly without any errors.
  - Running `expo config --type introspect` showed all of the desired config changes in Info.plist, and entitlements files.

Modified some values and in the config plugin and updated with `expo prebuild` and `yarn ios`, `yarn android`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
