### PR TITLE
Add support for waist circumference

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.h
@@ -21,6 +21,10 @@
 - (void)body_getHeightSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)body_saveHeight:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
+- (void)body_getLatestWaistCircumference:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)body_getWaistCircumferenceSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)body_saveWaistCircumference:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+
 - (void)body_getLatestBodyFatPercentage:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)body_getBodyFatPercentageSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)body_saveBodyFatPercentage:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
@@ -218,6 +218,85 @@
     }];
 }
 
+- (void)body_getLatestWaistCircumference:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *waistCircumferenceType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierWaistCircumference];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit inchUnit]];;
+
+    [self fetchMostRecentQuantitySampleOfType:waistCircumferenceType
+                                    predicate:nil
+                                   completion:^(HKQuantity *mostRecentQuantity, NSDate *startDate, NSDate *endDate, NSError *error) {
+        if (!mostRecentQuantity) {
+            NSLog(@"error getting latest waist circumference: %@", error);
+            callback(@[RCTMakeError(@"error getting latest wait circumference", error, nil)]);
+        }
+        else {
+            // Determine the waist circumference in the required unit.
+            double waistCircumference = [mostRecentQuantity doubleValueForUnit:unit];
+
+            NSDictionary *response = @{
+                    @"value" : @(waistCircumference),
+                    @"startDate" : [RCTAppleHealthKit buildISO8601StringFromDate:startDate],
+                    @"endDate" : [RCTAppleHealthKit buildISO8601StringFromDate:endDate],
+            };
+
+            callback(@[[NSNull null], response]);
+        }
+    }];
+}
+
+
+- (void)body_getWaistCircumferenceSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *waistCircumferenceType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierWaistCircumference];
+
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit inchUnit]];
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+    NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+
+    [self fetchQuantitySamplesOfType:waistCircumferenceType
+                                unit:unit
+                           predicate:predicate
+                           ascending:ascending
+                               limit:limit
+                          completion:^(NSArray *results, NSError *error) {
+        if(results){
+          callback(@[[NSNull null], results]);
+          return;
+        } else {
+          callback(@[RCTJSErrorFromNSError(error)]);
+          return;
+        }
+    }];
+}
+
+
+- (void)body_saveWaistCircumference:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    double waistCircumference = [RCTAppleHealthKit doubleValueFromOptions:input];
+    NSDate *sampleDate = [RCTAppleHealthKit dateFromOptionsDefaultNow:input];
+    HKUnit *waistCircumferenceUnit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit inchUnit]];
+
+    HKQuantity *waistCircumferenceQuantity = [HKQuantity quantityWithUnit:waistCircumferenceUnit doubleValue:waistCircumference];
+    HKQuantityType *waistCircumferenceType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierWaistCircumference];
+    HKQuantitySample *waistCircumferenceSample = [HKQuantitySample quantitySampleWithType:waistCircumferenceType quantity:waistCircumferenceQuantity startDate:sampleDate endDate:sampleDate];
+
+    [self.healthStore saveObject:waistCircumferenceSample withCompletion:^(BOOL success, NSError *error) {
+        if (!success) {
+            callback(@[RCTJSErrorFromNSError(error)]);
+            return;
+        }
+        callback(@[[NSNull null], @(waistCircumference)]);
+    }];
+}
+
 
 - (void)body_getLatestBodyFatPercentage:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -27,6 +27,8 @@
         return [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBiologicalSex];
     } else if ([@"BloodType" isEqualToString: key]) {
         return [HKObjectType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBloodType];
+    } else if ([@"WaistCircumference" isEqualToString: key] && systemVersion >= 11.0) {
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierWaistCircumference];
     }
 
     // Body Measurements
@@ -195,6 +197,8 @@
     // Body Measurements
     if ([@"Height" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierHeight];
+    } else if ([@"WaistCircumference" isEqualToString:key]) {
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierWaistCircumference];
     } else if ([@"Weight" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyMass];
     } else if ([@"BodyMass" isEqualToString:key]) {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -100,6 +100,24 @@ RCT_EXPORT_METHOD(saveHeight:(NSDictionary *)input callback:(RCTResponseSenderBl
     [self body_saveHeight:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getLatestWaistCircumference:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self body_getLatestWaistCircumference:input callback:callback];
+}
+
+RCT_EXPORT_METHOD(getWaistCircumferenceSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self body_getWaistCircumferenceSamples:input callback:callback];
+}
+
+RCT_EXPORT_METHOD(saveWaistCircumference:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self body_saveWaistCircumference:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getLatestBmi:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,9 @@ There is a gitbook version for the documentation on this [link](https://vinicius
 
 - [getLatestHeight](getLatestHeight.md)
 - [getLatestWeight](getLatestWeight.md)
+- [getLatestWaistCircumference](getLatestWaistCircumference.md)
 - [getHeightSamples](getHeightSamples.md)
+- [getWaistCircumferenceSamples](getWaistCircumferenceSamples.md)
 - [getWeightSamples](getWeightSamples.md)
 - [getBodyTemperatureSamples](getBodyTemperatureSamples.md)
 - [getLatestBodyFatPercentage](getLatestBodyFatPercentage.md)
@@ -38,6 +40,7 @@ There is a gitbook version for the documentation on this [link](https://vinicius
 - [getLatestLeanBodyMass](getLatestLeanBodyMass.md)
 - [getLeanBodyMassSamples](getLeanBodyMassSamples.md)
 - [saveHeight](saveHeight.md)
+- [saveWaistCircumference](saveWaistCircumference.md)
 - [saveWeight](saveWeight.md)
 - [saveBodyFatPercentage](saveBodyFatPercentage.md)
 - [saveBodyTemperature](/docs/saveBodyTemperature.md)

--- a/docs/getLatestWaistCircumference.md
+++ b/docs/getLatestWaistCircumference.md
@@ -1,0 +1,25 @@
+# getLatestWaistCircumference
+
+Get the most recent waist circumference value. Waist circumference is available in iOS 11.0+.
+
+On success, the callback function will be provided with a `waistCircumference` object containing the waist circumference `value`, and the `startDate` and `endDate` of the waist circumference sample. _Note: startDate and endDate will be the same as waist circumference samples are saved at a specific point in time._
+
+```javascript
+AppleHealthKit.getLatestWaistCircumference({}, (err: string, results: HealthValue) => {
+  if (err) {
+    console.log('error getting latest waist circumference: ', err)
+    return
+  }
+  console.log(results)
+})
+```
+
+Example output:
+
+```json
+{
+  "value": 39,
+  "startDate": "2021-06-15T11:08:05.366+0100",
+  "endDate": "2021-06-15T11:08:05.366+0100"
+}
+```

--- a/docs/getWaistCircumferenceSamples.md
+++ b/docs/getWaistCircumferenceSamples.md
@@ -1,0 +1,46 @@
+# getWaistCircumferenceSamples
+
+Query for waist circumference samples. The options object is used to setup a query to retrieve relevant samples. Waist circumference is available in iOS 11.0+.
+
+Example input options:
+
+```javascript
+let options = {
+  unit: 'inch', // optional; default 'inch'
+  startDate: new Date(2021, 0, 0).toISOString(), // required
+  endDate: new Date().toISOString(), // optional; default now
+  ascending: false, // optional; default false
+  limit: 10, // optional; default no limit
+}
+```
+
+Call the method:
+
+```javascript
+AppleHealthKit.getWaistCircumferenceSamples(
+  options,
+  (err: Object, results: Array<HealthValue>) => {
+    if (err) {
+      return
+    }
+    console.log(results)
+  },
+)
+```
+
+Example output:
+
+```json
+[
+  {
+    "value": 39.02,
+    "startDate": "2016-06-29T17:55:00.000-0400",
+    "endDate": "2016-06-29T17:55:00.000-0400"
+  },
+  {
+    "value": 39,
+    "startDate": "2016-03-12T13:22:00.000-0400",
+    "endDate": "2016-03-12T13:22:00.000-0400"
+  }
+]
+```

--- a/docs/saveWaistCircumference.md
+++ b/docs/saveWaistCircumference.md
@@ -1,0 +1,33 @@
+# saveWaistCircumference
+
+save a numeric waist circumference value to Healthkit. Waist circumference is available in iOS 11.0+.
+
+`saveWaistCircumference` accepts an options object containing a numeric waist circumference value:
+
+Example input options:
+
+```javascript
+let options = {
+  value: 39, // Inches
+}
+```
+
+Call the method:
+
+```javascript
+AppleHealthKit.saveWaistCircumference(
+  (options: HealthValueOptions),
+  (err: Object, results: number) => {
+    if (err) {
+      return
+    }
+    // waist circumference successfully saved
+  },
+)
+```
+
+Example output:
+
+```json
+39
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,21 @@ declare module 'react-native-health' {
       options: HealthValueOptions,
       callback: (error: string, result: HealthValue) => void,
     ): void
+    
+    getLatestWaistCircumference(
+      options: HealthUnitOptions,
+      callback: (err: string, results: HealthValue) => void,
+    ): void
+
+    getWaistCircumferenceSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    saveWaistCircumference(
+      options: HealthValueOptions,
+      callback: (error: string, result: HealthValue) => void,
+    ): void
 
     saveLeanBodyMass(
       options: HealthValueOptions,
@@ -559,6 +574,7 @@ declare module 'react-native-health' {
     Vo2Max = 'Vo2Max',
     Weight = 'Weight',
     Workout = 'Workout',
+    WaistCircumference = 'WaistCircumference'
   }
 
   export enum HealthUnit {

--- a/src/constants/Permissions.js
+++ b/src/constants/Permissions.js
@@ -74,6 +74,7 @@ export const Permissions = {
   StepCount: 'StepCount',
   Steps: 'Steps',
   Vo2Max: 'Vo2Max',
+  WaistCircumference: 'WaistCircumference',
   Weight: 'Weight',
   Workout: 'Workout',
 }


### PR DESCRIPTION
## Description

This PR adds support for [waist circumference](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifierwaistcircumference/) to `react-native-health` library.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings


## Screenshot
![image](https://user-images.githubusercontent.com/1014725/122074594-3f6f4000-cdf1-11eb-9419-4490a4f83715.png)
