### PR TITLE
Expose HealthKit Object UUID in samples responses

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -86,6 +86,7 @@
 
                     NSDictionary *elem = @{
                             @"value" : @(value),
+                            @"id" : [[sample UUID] UUIDString],
                             @"sourceName" : [[[sample sourceRevision] source] name],
                             @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
                             @"startDate" : startDateString,

--- a/docs/getBloodAlcoholContentSamples.md
+++ b/docs/getBloodAlcoholContentSamples.md
@@ -32,6 +32,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2020-09-29T22:09:35.527+0200",
     "sourceId": "com.example.app",
     "sourceName": "app",
@@ -39,6 +40,7 @@ Example output:
     "value": 0.003
   },
   {
+    "id": "30977632-ba69-4405-8e91-63dc882e8a45",
     "endDate": "2020-09-29T21:52:00.000+0200",
     "sourceId": "com.apple.Health",
     "sourceName": "Helse",
@@ -46,6 +48,7 @@ Example output:
     "value": 0.001
   },
   {
+    "id": "be028840-3e08-4532-8e57-145637affd2b",
     "endDate": "2020-09-28T22:46:00.000+0200",
     "sourceId": "com.apple.Health",
     "sourceName": "Helse",

--- a/docs/getBloodGlucoseSamples.md
+++ b/docs/getBloodGlucoseSamples.md
@@ -33,6 +33,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-03-22T16:19:00.000-0300",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",

--- a/docs/getBodyFatPercentageSamples.md
+++ b/docs/getBodyFatPercentageSamples.md
@@ -32,16 +32,19 @@ Example output:
 ```json
 [
   {
+    "id": "3d366e60-4f7c-4f72-b0ce-479ea19279b8", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 16.5,
     "startDate": "2016-07-09T00:00:00.000-0400",
     "endDate": "2016-07-10T00:00:00.000-0400"
   },
   {
+    "id": "ba13089a-a311-4ffe-9352-f5c568936f16",
     "value": 16.1,
     "startDate": "2016-07-08T00:00:00.000-0400",
     "endDate": "2016-07-09T00:00:00.000-0400"
   },
   {
+    "id": "2292e713-636e-45a1-acd8-365397f6efed",
     "value": 15.9,
     "startDate": "2016-07-07T00:00:00.000-0400",
     "endDate": "2016-07-08T00:00:00.000-0400"

--- a/docs/getBodyTemperatureSamples.md
+++ b/docs/getBodyTemperatureSamples.md
@@ -33,11 +33,13 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 74.02,
     "startDate": "2016-06-29T17:55:00.000-0400",
     "endDate": "2016-06-29T17:55:00.000-0400"
   },
   {
+    "id": "1128b739-357d-4044-9205-3a287658aac1",
     "value": 74,
     "startDate": "2016-03-12T13:22:00.000-0400",
     "endDate": "2016-03-12T13:22:00.000-0400"

--- a/docs/getCarbohydratesSamples.md
+++ b/docs/getCarbohydratesSamples.md
@@ -31,6 +31,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-03-22T16:21:00.000-0300",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",

--- a/docs/getHeartRateSamples.md
+++ b/docs/getHeartRateSamples.md
@@ -31,11 +31,13 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 74.02,
     "startDate": "2016-06-29T17:55:00.000-0400",
     "endDate": "2016-06-29T17:55:00.000-0400"
   },
   {
+    "id": "4ea9e479-86e2-4e82-8030-86a9a9b8e569",
     "value": 74,
     "startDate": "2016-03-12T13:22:00.000-0400",
     "endDate": "2016-03-12T13:22:00.000-0400"

--- a/docs/getHeartRateVariabilitySamples.md
+++ b/docs/getHeartRateVariabilitySamples.md
@@ -31,6 +31,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 0.4223,
     "startDate": "2016-03-12T13:22:00.000-0400",
     "endDate": "2016-03-12T13:22:00.000-0400"

--- a/docs/getHeightSamples.md
+++ b/docs/getHeightSamples.md
@@ -33,11 +33,13 @@ Example output:
 ```json
 [
   {
+    "id": "3d366e60-4f7c-4f72-b0ce-479ea19279b8", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 74.02,
     "startDate": "2016-06-29T17:55:00.000-0400",
     "endDate": "2016-06-29T17:55:00.000-0400"
   },
   {
+    "id": "19a9910d-230a-437f-a830-353f6e61f676",
     "value": 74,
     "startDate": "2016-03-12T13:22:00.000-0400",
     "endDate": "2016-03-12T13:22:00.000-0400"

--- a/docs/getLeanBodyMassSamples.md
+++ b/docs/getLeanBodyMassSamples.md
@@ -33,16 +33,19 @@ Example output:
 ```json
 [
   {
+    "id": "ba13089a-a311-4ffe-9352-f5c568936f16", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 160,
     "startDate": "2016-07-09T00:00:00.000-0400",
     "endDate": "2016-07-10T00:00:00.000-0400"
   },
   {
+    "id": "b50407fa-44a7-4f12-9348-74c63748b38b",
     "value": 161,
     "startDate": "2016-07-08T00:00:00.000-0400",
     "endDate": "2016-07-09T00:00:00.000-0400"
   },
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51",
     "value": 165,
     "startDate": "2016-07-07T00:00:00.000-0400",
     "endDate": "2016-07-08T00:00:00.000-0400"

--- a/docs/getOxygenSaturationSamples.md
+++ b/docs/getOxygenSaturationSamples.md
@@ -32,6 +32,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-03-04T10:56:00.000-0500",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",
@@ -39,6 +40,7 @@ Example output:
     "value": 0.98
   },
   {
+    "id": "86ff59e7-f393-4f32-95fb-b0bf7027374d",
     "endDate": "2021-03-04T09:55:00.000-0500",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",
@@ -46,6 +48,7 @@ Example output:
     "value": 0.97
   },
   {
+    "id": "b8239909-e519-4e33-af3e-d87db605ae97",
     "endDate": "2021-03-04T08:00:00.000-0500",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",
@@ -53,6 +56,7 @@ Example output:
     "value": 0.95
   },
   {
+    "id": "349fb170-86db-4857-9ffb-c70fb4510bac",
     "endDate": "2021-03-03T21:43:00.000-0500",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",

--- a/docs/getProteinSamples.md
+++ b/docs/getProteinSamples.md
@@ -34,6 +34,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-04-01T22:00:00.000+0300", 
     "startDate": "2021-04-01T22:00:00.000+0300", 
     "value": 39

--- a/docs/getRespiratoryRateSamples.md
+++ b/docs/getRespiratoryRateSamples.md
@@ -31,6 +31,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-03-22T16:32:00.000-0300",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",

--- a/docs/getRestingHeartRateSamples.md
+++ b/docs/getRestingHeartRateSamples.md
@@ -31,6 +31,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 74,
     "startDate": "2016-03-12T13:22:00.000-0400",
     "endDate": "2016-03-12T13:22:00.000-0400"

--- a/docs/getVo2MaxSamples.md
+++ b/docs/getVo2MaxSamples.md
@@ -33,6 +33,7 @@ Example output:
 ```json
 [
   {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-03-22T16:35:00.000-0300",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",

--- a/docs/getWeightSamples.md
+++ b/docs/getWeightSamples.md
@@ -33,16 +33,19 @@ Example output:
 ```json
 [
   {
+    "id": "3d366e60-4f7c-4f72-b0ce-479ea19279b8", // The universally unique identifier (UUID) for this HealthKit object.
     "value": 160,
     "startDate": "2016-07-09T00:00:00.000-0400",
     "endDate": "2016-07-10T00:00:00.000-0400"
   },
   {
+    "id": "cb7a2de6-f8d2-48cc-8cca-3d9f58a3601a",
     "value": 161,
     "startDate": "2016-07-08T00:00:00.000-0400",
     "endDate": "2016-07-09T00:00:00.000-0400"
   },
   {
+    "id": "4dddd4da-2adf-4d1c-a400-10790ffe2c0d",
     "value": 165,
     "startDate": "2016-07-07T00:00:00.000-0400",
     "endDate": "2016-07-08T00:00:00.000-0400"

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ declare module 'react-native-health' {
       options: HealthValueOptions,
       callback: (error: string, result: HealthValue) => void,
     ): void
-    
+
     saveLeanBodyMass(
       options: HealthValueOptions,
       callback: (error: string, result: HealthValue) => void,

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ declare module 'react-native-health' {
       options: HealthValueOptions,
       callback: (error: string, result: HealthValue) => void,
     ): void
-
+    
     saveLeanBodyMass(
       options: HealthValueOptions,
       callback: (error: string, result: HealthValue) => void,
@@ -345,6 +345,7 @@ declare module 'react-native-health' {
     age: number
   }
   interface BaseValue {
+    id?: string
     startDate: string
     endDate: string
   }


### PR DESCRIPTION
## Description

This PR exposes [HealthKit Object UUID](https://developer.apple.com/documentation/healthkit/hkobject/1615721-uuid) in samples responses. This extra field would allow applications to be able to know deterministically if a value is different from one sync'ed before, which is handy for scenarios where the data is being stored by the application client or server-side. Otherwise, they'd have to rely on `startDate` / `endDate` to identify HK objects which might not be reliable.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
