### PR TITLE
Performance fix for statistics queries

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -513,7 +513,10 @@
                                                      fromDate:[NSDate date]];
     anchorComponents.hour = 0;
     NSDate *anchorDate = [calendar dateFromComponents:anchorComponents];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES", HKMetadataKeyWasUserEntered];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES AND %K >= %@ AND %K <= %@",
+                              HKMetadataKeyWasUserEntered,
+                              HKPredicateKeyPathEndDate, startDate,
+                              HKPredicateKeyPathStartDate, endDate];
     // Create the query
     HKStatisticsCollectionQuery *query = [[HKStatisticsCollectionQuery alloc] initWithQuantityType:quantityType
                                                                            quantitySamplePredicate:predicate
@@ -567,7 +570,10 @@
                                                      fromDate:[NSDate date]];
     anchorComponents.hour = 0;
     NSDate *anchorDate = [calendar dateFromComponents:anchorComponents];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES", HKMetadataKeyWasUserEntered];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES AND %K >= %@ AND %K <= %@",
+                              HKMetadataKeyWasUserEntered,
+                              HKPredicateKeyPathEndDate, startDate,
+                              HKPredicateKeyPathStartDate, endDate];
     // Create the query
     HKStatisticsCollectionQuery *query = [[HKStatisticsCollectionQuery alloc] initWithQuantityType:quantityType
                                                                            quantitySamplePredicate:predicate
@@ -643,7 +649,14 @@
     NSDate *anchorDate = [calendar dateFromComponents:anchorComponents];
     NSPredicate *predicate = nil;
     if (includeManuallyAdded == false) {
-        predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES", HKMetadataKeyWasUserEntered];
+        predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES AND %K >= %@ AND %K <= %@",
+                                  HKMetadataKeyWasUserEntered,
+                                  HKPredicateKeyPathEndDate, startDate,
+                                  HKPredicateKeyPathStartDate, endDate];
+    } else {
+        predicate = [NSPredicate predicateWithFormat:@"%K >= %@ AND %K <= %@",
+                                  HKPredicateKeyPathEndDate, startDate,
+                                  HKPredicateKeyPathStartDate, endDate];
     }
     // Create the query
     HKStatisticsCollectionQuery *query = [[HKStatisticsCollectionQuery alloc] initWithQuantityType:quantityType


### PR DESCRIPTION
## Description

We bumped into a problem where having 43k+ step entries over 10 years in Apple Health but we only wanted data from the past 7 days, yet the query took 2k+ ms. After playing with the `period` parameter I managed to get it down to 400ms, but I realised that the query unnecessarily fetches all the data available and then applies `startDate` and `endDate`.

This can be improved by changing the `NSPredicate` so that it includes the date condition. This got my query down to `<20ms`.

Fixes # (issue)

```
NSPredicate *predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES AND %K >= %@ AND %K <= %@",
                              HKMetadataKeyWasUserEntered,
                              HKPredicateKeyPathEndDate, startDate,
                              HKPredicateKeyPathStartDate, endDate];
```

https://developer.apple.com/documentation/healthkit/hkquery/1614771-predicateforsampleswithstartdate

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
