### PR TITLE
fix(types): fix getAnchoredWorkouts error type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,10 @@ declare module 'react-native-health' {
     Units: Record<HealthUnit, HealthUnit>
   }
 
+  export interface HKErrorResponse {
+    message?: string;
+  }
+
   export interface AppleHealthKit {
     initHealthKit(
       permissions: HealthKitPermissions,
@@ -120,7 +124,7 @@ declare module 'react-native-health' {
 
     getAnchoredWorkouts(
       options: HealthInputOptions,
-      callback: (err: string, results: AnchoredQueryResults) => void,
+      callback: (err: HKErrorResponse, results: AnchoredQueryResults) => void,
     ): void
 
     getDailyStepCountSamples(


### PR DESCRIPTION
## Description

`getAnchoredWorkouts` callback function was typing the error param as `string`,

But using the library we realized that the actual error is an object with a `message` prop, this PR adds a interface for this error and change the type of error param.

The [function docs](https://github.com/agencyenterprise/react-native-health/blob/master/docs/getAnchoredWorkouts.md) also shows `error` param as an Object.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
