### PR TITLE
Fix lib class being instantiated twice and using wrong hasListeners

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -911,12 +911,12 @@
             completionHandler();
 
             NSLog(@"[HealthKit] An error happened when receiving a new sample - %@", error.localizedDescription);
-            if(hasListeners) {
+            if(self.hasListeners) {
                 [self sendEventWithName:failureEvent body:@{}];
             }
             return;
         }
-        if(hasListeners) {
+        if(self.hasListeners) {
             [self sendEventWithName:successEvent body:@{}];
         }
         completionHandler();
@@ -933,14 +933,14 @@
 
         if (error) {
             NSLog(@"[HealthKit] An error happened when setting up background observer - %@", error.localizedDescription);
-            if(hasListeners) {
+            if(self.hasListeners) {
                 [self sendEventWithName:failureEvent body:@{}];
             }
             return;
         }
 
         [self.healthStore executeQuery:query];
-        if(hasListeners) {
+        if(self.hasListeners) {
             [self sendEventWithName:successEvent body:@{}];
         }
         }];

--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -18,6 +18,7 @@
 @interface RCTAppleHealthKit : RCTEventEmitter <RCTBridgeModule>
 
 @property (nonatomic) HKHealthStore *healthStore;
+@property (nonatomic, assign) BOOL hasListeners;
 
 - (HKHealthStore *)_initializeHealthStore;
 - (void)isHealthKitAvailable:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -27,6 +27,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 
+RCTAppleHealthKit *shared;
+
 @implementation RCTAppleHealthKit
 
 @synthesize bridge = _bridge;
@@ -34,6 +36,22 @@
 bool hasListeners;
 
 RCT_EXPORT_MODULE();
+
+- (id) init
+{
+    if (shared != nil) {
+        return shared;
+    }
+
+    self = [super init];
+    shared = self;
+    return self;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
 
 RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
 {
@@ -711,13 +729,13 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
 
 // Will be called when this module's first listener is added.
 -(void)startObserving {
-    hasListeners = YES;
+    self.hasListeners = YES;
     // Set up any upstream listeners or background tasks as necessary
 }
 
 // Will be called when this module's last listener is removed, or on dealloc.
 -(void)stopObserving {
-    hasListeners = NO;
+    self.hasListeners = NO;
     // Remove upstream listeners, stop unnecessary background tasks
 }
 


### PR DESCRIPTION
## Description

Fix background observers issue #144 

- hasListeners is now a class property
- library now acts as a singleton
- 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
