### PR TITLE
(#120) Add getBodyFatPercentageSample+getLeanBodyMassSamples APIs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,9 +107,19 @@ declare module 'react-native-health' {
       callback: (err: string, results: HealthValue) => void,
     ): void
 
+    getBodyFatPercentageSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
     getLatestLeanBodyMass(
       options: HealthUnitOptions,
       callback: (err: string, results: HealthValue) => void,
+    ): void
+
+    getLeanBodyMassSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     getStepCount(


### PR DESCRIPTION
## Description

[getBodyFatPercentageSamples](https://github.com/agencyenterprise/react-native-health/blob/master/docs/getBodyFatPercentageSamples.md) & [getLeanBodyMassSamples](https://github.com/agencyenterprise/react-native-health/blob/master/docs/getLeanBodyMassSamples.md) APIs exist in the
documentation but are not exposed in the TypeScript API layer.
This change exposes them so they can be used as documented.

Fixes #120

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
