### PR TITLE
Add support of getBmiSamples method

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.h
@@ -15,6 +15,7 @@
 - (void)body_saveWeight:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 - (void)body_getLatestBodyMassIndex:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)body_getBodyMassIndexSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)body_saveBodyMassIndex:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 - (void)body_getLatestHeight:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Body.m
@@ -118,6 +118,37 @@
     }];
 }
 
+- (void)body_getBodyMassIndexSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *bmiType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBodyMassIndex];
+
+    HKUnit *countUnit = [HKUnit countUnit];
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+    NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+
+    [self fetchQuantitySamplesOfType:bmiType
+                                unit:countUnit
+                           predicate:predicate
+                           ascending:ascending
+                               limit:limit
+                          completion:^(NSArray *results, NSError *error) {
+        if(results){
+          callback(@[[NSNull null], results]);
+          return;
+        } else {
+          callback(@[RCTJSErrorFromNSError(error)]);
+          return;
+        }
+    }];
+}
+
 
 - (void)body_saveBodyMassIndex:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -147,6 +147,12 @@ RCT_EXPORT_METHOD(getLatestBmi:(NSDictionary *)input callback:(RCTResponseSender
     [self body_getLatestBodyMassIndex:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getBmiSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self body_getBodyMassIndexSamples:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(saveBmi:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ they are splitted in the following categories
 - [getRestingHeartRateSamples](/docs/getRestingHeartRateSamples.md)
 - [getVo2MaxSamples](/docs/getVo2MaxSamples.md)
 - [getLatestBmi](/docs/getLatestBmi.md)
+- [getBmiSamples](/docs/getBmiSamples.md)
 - [getRespiratoryRateSamples](/docs/getRespiratoryRateSamples.md)
 - [getWalkingHeartRateAverage](/docs/getWalkingHeartRateAverage.md)
 - [saveBmi](/docs/saveBmi.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -110,6 +110,7 @@
 * [getRestingHeartRateSamples](/docs/getRestingHeartRateSamples.md)
 * [getVo2MaxSamples](/docs/getVo2MaxSamples.md)
 * [getLatestBmi](/docs/getLatestBmi.md)
+* [getBmiSamples](/docs/getBmiSamples.md)
 * [getRespiratoryRateSamples](/docs/getRespiratoryRateSamples.md)
 * [getWalkingHeartRateAverage](/docs/getWalkingHeartRateAverage.md)
 * [saveBmi](/docs/saveBmi.md)

--- a/docs/getBmiSamples.md
+++ b/docs/getBmiSamples.md
@@ -1,0 +1,49 @@
+# getBmiSamples
+
+Query for BMI samples. The options object is used to setup a query to retrieve relevant samples.
+
+Example input options:
+
+```javascript
+let options = {
+  startDate: new Date(2021, 0, 0).toISOString(), // required
+  endDate: new Date().toISOString(), // optional; default now
+  ascending: false, // optional; default false
+  limit: 10, // optional; default no limit
+}
+```
+
+```javascript
+AppleHealthKit.getBmiSamples(
+  options,
+  (err: Object, results: Array<HealthValue>) => {
+    if (err) {
+      return
+    }
+    console.log(results)
+  },
+)
+```
+
+Example output:
+
+```json
+[
+  {
+    "endDate": "2021-10-10T09:19:00.000+0000", 
+    "id": "73A653BA-4715-47BD-98FE-E9AA91DB33CA", // The universally unique identifier (UUID) for this HealthKit object.
+    "sourceId": "com.apple.Health", 
+    "sourceName": "Health", 
+    "startDate": "2021-10-19T09:19:00.000+0000", 
+    "value": 18.5
+  },
+  {
+    "endDate": "2021-08-23T08:50:00.000+0000",
+    "id": "B3D8B5BE-216C-4C10-A96E-3B2CF8EB646E",
+    "sourceId": "com.apple.Health",
+    "sourceName": "Health",
+    "startDate": "2021-08-23T08:50:00.000+0000",
+    "value": 18.83
+  }
+]
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,6 +97,11 @@ declare module 'react-native-health' {
       callback: (err: string, results: HealthValue) => void,
     ): void
 
+    getBmiSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+  
     saveBmi(
       options: HealthValueOptions,
       callback: (error: string, result: HealthValue) => void,


### PR DESCRIPTION
## Description
User can add Body Mass Index to Apple Health Kit, however body mass index samples getter is missing. 
Using HKSampleQuery we can fetch HKQuantityTypeIdentifierBodyMassIndex samples. 

Fixes #169

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
