### PR TITLE
Add Sleep sample unique identifier (UUID) to returned response

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -443,6 +443,7 @@
                   }
 
                     NSDictionary *elem = @{
+                            @"id" : [[sample UUID] UUIDString],
                             @"value" : valueString,
                             @"startDate" : startDateString,
                             @"endDate" : endDateString,

--- a/docs/getSleepSamples.md
+++ b/docs/getSleepSamples.md
@@ -35,6 +35,7 @@ Example output:
 ```json
 [
   {
+    "id": "3d366e60-4f7c-4f72-b0ce-479ea19279b8", // The universally unique identifier (UUID) for this HealthKit object.
     "endDate": "2021-03-22T16:34:00.000-0300",
     "sourceId": "com.apple.Health",
     "sourceName": "Health",


### PR DESCRIPTION
## Description
This PR exposes HealthKit Object UUID in Sleep samples responses. This extra field would allow applications to be able to know deterministically if a value is different from one sync'ed before, which is handy for scenarios where the data is being stored by the application client or server-side. Otherwise, they'd have to rely on startDate / endDate to identify HK objects which might not be reliable.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
