### PR TITLE
Add conversion for count/min samples (e.g. HeartRate)

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -13,6 +13,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 
+#define kCountPerMinUnitStr @"count/min"
+
 @implementation RCTAppleHealthKit (Queries)
 
 - (void)fetchMostRecentQuantitySampleOfType:(HKQuantityType *)quantityType


### PR DESCRIPTION
## Description

Unit conversion to double fails when consuming count/min samples (e.g. HeartRate) in background mode. See [here](https://github.com/agencyenterprise/react-native-health/issues/166#issuecomment-1012444710)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
