### PR TITLE
Correct type for results of getMindfulSession

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -324,7 +324,7 @@ declare module 'react-native-health' {
 
     getMindfulSession(
       options: HealthInputOptions,
-      callback: (err: string, results: HealthValue) => void,
+      callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
     saveMindfulSession(


### PR DESCRIPTION
## Description

getMindfulSession had incorrect type set for return value. It should be Array<HealthValue> instead of HealthValue.

docs are correct: https://github.com/agencyenterprise/react-native-health/blob/master/docs/getMindfulSession.md

code returns array: https://github.com/agencyenterprise/react-native-health/blob/5ac69836806b21dbe46f65493bb29a43ba046a6a/RCTAppleHealthKit/RCTAppleHealthKit%2BMethods_Mindfulness.m#L41

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
