### PR TITLE
issue-201 possible fix

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -865,11 +865,12 @@
             return;
         }
 
-        [self sendEventWithName:successEvent body:@{}];
+        NSLog(@"Emtting event: %@", successEvent);
+        [self emitEventWithName:successEvent andPayload:@{}];
 
         completionHandler();
 
-        NSLog(@"[HealthKit] New sample from Apple HealthKit processed - %@", type);
+        NSLog(@"[HealthKit] New sample from Apple HealthKit processed (dep) - %@ %@", type, successEvent);
     }];
 
 
@@ -886,7 +887,7 @@
 
         [self.healthStore executeQuery:query];
 
-        [self sendEventWithName:successEvent body:@{}];
+        [self emitEventWithName:successEvent andPayload:@{}];
     }];
 }
 
@@ -919,16 +920,19 @@
 
             NSLog(@"[HealthKit] An error happened when receiving a new sample - %@", error.localizedDescription);
             if(self.hasListeners) {
-                [self sendEventWithName:failureEvent body:@{}];
+                [self emitEventWithName:failureEvent andPayload:@{}];
             }
             return;
         }
+
         if(self.hasListeners) {
-            [self sendEventWithName:successEvent body:@{}];
+            [self emitEventWithName:successEvent andPayload:@{}];
+        } else {
+          NSLog(@"has no listeners for %@", successEvent);
         }
         completionHandler();
 
-        NSLog(@"[HealthKit] New sample from Apple HealthKit processed - %@", type);
+        NSLog(@"[HealthKit] New sample from Apple HealthKit processed - %@ %@", type, successEvent);
     }];
 
 
@@ -941,15 +945,16 @@
         if (error) {
             NSLog(@"[HealthKit] An error happened when setting up background observer - %@", error.localizedDescription);
             if(self.hasListeners) {
-                [self sendEventWithName:failureEvent body:@{}];
+                [self emitEventWithName:failureEvent andPayload:@{}];
             }
             return;
         }
-
+        NSLog(@"[HealthKit] Background delivery enabled for %@", type);
         [self.healthStore executeQuery:query];
-        if(self.hasListeners) {
-            [self sendEventWithName:successEvent body:@{}];
-        }
+          if(self.hasListeners) {
+              NSLog(@"[HealthKit] Background observer set up for %@", type);
+              [self emitEventWithName:successEvent andPayload:@{}];
+          }
         }];
 }
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -865,7 +865,7 @@
             return;
         }
 
-        NSLog(@"Emtting event: %@", successEvent);
+        NSLog(@"Emitting event: %@", successEvent);
         [self emitEventWithName:successEvent andPayload:@{}];
 
         completionHandler();
@@ -928,7 +928,7 @@
         if(self.hasListeners) {
             [self emitEventWithName:successEvent andPayload:@{}];
         } else {
-          NSLog(@"has no listeners for %@", successEvent);
+          NSLog(@"There is no listeners for %@", successEvent);
         }
         completionHandler();
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.h
@@ -23,9 +23,9 @@
 - (HKHealthStore *)_initializeHealthStore;
 - (void)isHealthKitAvailable:(RCTResponseSenderBlock)callback;
 - (void)initializeHealthKit:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
-- (void)checkPermission:(NSString *)input callback:(RCTResponseSenderBlock)callback;
 - (void)getModuleInfo:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)getAuthorizationStatus:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)initializeBackgroundObservers:(RCTBridge *)bridge;
+- (void)emitEventWithName:(NSString *)name andPayload:(NSDictionary *)payload;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -27,25 +27,35 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 
-RCTAppleHealthKit *shared;
 
 @implementation RCTAppleHealthKit
-
-@synthesize bridge = _bridge;
 
 bool hasListeners;
 
 RCT_EXPORT_MODULE();
 
+
++ (id)allocWithZone:(NSZone *)zone {
+    static RCTAppleHealthKit *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [super allocWithZone:zone];
+    });
+    return sharedInstance;
+}
+
++ (RCTCallableJSModules *)sharedJsModule {
+    static RCTCallableJSModules *sharedJsModule = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedJsModule = [RCTCallableJSModules new];
+    });
+    return sharedJsModule;
+}
+
 - (id) init
 {
-    if (shared != nil) {
-        return shared;
-    }
-
-    self = [super init];
-    shared = self;
-    return self;
+    return [super init];
 }
 
 + (BOOL)requiresMainQueueSetup
@@ -583,7 +593,7 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
         [self.healthStore requestAuthorizationToShareTypes:writeDataTypes readTypes:readDataTypes completion:^(BOOL success, NSError *error) {
             if (!success) {
                 NSString *errMsg = [NSString stringWithFormat:@"Error with HealthKit authorization: %@", error];
-                NSLog(errMsg);
+                 NSLog(@"%@", errMsg);
                 callback(@[RCTMakeError(errMsg, nil, nil)]);
                 return;
             } else {
@@ -662,8 +672,8 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
         if(permissions != nil && [permissions objectForKey:@"read"] != nil && [permissions objectForKey:@"write"] != nil){
             NSArray* readPermsNamesArray = [permissions objectForKey:@"read"];
             NSArray* writePermsNamesArray = [permissions objectForKey:@"write"];
-            readPermsArray = [self getReadPermsFromOptions:readPermsNamesArray];
-            writePermsArray = [self getWritePermsFromOptions:writePermsNamesArray];
+            readPermsArray = [[self getReadPermsFromOptions:readPermsNamesArray] allObjects];
+            writePermsArray = [[self getWritePermsFromOptions:writePermsNamesArray] allObjects];
         } else {
             callback(@[RCTMakeError(@"permissions must be included in permissions object with read and write options", nil, nil)]);
             return;
@@ -696,10 +706,8 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
 
     This method must be called at the application:didFinishLaunchingWithOptions: method, in AppDelegate.m
  */
-- (void)initializeBackgroundObservers:(RCTBridge *)bridge
+  - (void)initializeBackgroundObservers:(RCTBridge *)bridge
 {
-    NSLog(@"[HealthKit] Background observers will be added to the app");
-
     [self _initializeHealthStore];
 
     self.bridge = bridge;
@@ -751,14 +759,35 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
 
 // Will be called when this module's first listener is added.
 -(void)startObserving {
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        for (NSString *notificationName in [self supportedEvents]) {
+            [center addObserver:self
+                   selector:@selector(emitEventInternal:)
+                       name:notificationName
+                     object:nil];
+        }
     self.hasListeners = YES;
-    // Set up any upstream listeners or background tasks as necessary
+}
+
+- (void)emitEventInternal:(NSNotification *)notification {
+  if (self.hasListeners) {
+    self.callableJSModules = [RCTAppleHealthKit sharedJsModule];
+    [self.callableJSModules setBridge:self.bridge];
+    [self sendEventWithName:notification.name
+                   body:notification.userInfo];
+  }
+}
+
+- (void)emitEventWithName:(NSString *)name andPayload:(NSDictionary *)payload {
+    [[NSNotificationCenter defaultCenter] postNotificationName:name
+                                                    object:self
+                                                  userInfo:payload];
 }
 
 // Will be called when this module's last listener is removed, or on dealloc.
 -(void)stopObserving {
     self.hasListeners = NO;
-    // Remove upstream listeners, stop unnecessary background tasks
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end


### PR DESCRIPTION
## Description

Adding the line [[RCTAppleHealthKit new] initializeBackgroundObservers:bridge]; causes the app to crash when opening


## Type of change
Error when sending event: healthKit:ActiveEnergyBurned:setup:success with body: {\n}. RCTCallableJSModules is not set. This is probably because you've explicitly synthesized the RCTCallableJSModules in RCTAppleHealthKit, even though it's inherited from RCTEventEmitter

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
