### PR TITLE
Add missing clinical record type VitalSignRecord

### DIFF
--- a/docs/getClinicalRecords.md
+++ b/docs/getClinicalRecords.md
@@ -10,7 +10,7 @@ let options = {
   endDate: new Date().toISOString(), // optional; default now
   ascending: false, // optional; default false
   limit: 10, // optional; default no limit
-  type: 'AllergyRecord', // one of: ['AllergyRecord', 'ConditionRecord', 'CoverageRecord', 'ImmunizationRecord', 'LabResultRecord', 'MedicationRecord', 'ProcedureRecord']
+  type: 'AllergyRecord', // one of: ['AllergyRecord', 'ConditionRecord', 'CoverageRecord', 'ImmunizationRecord', 'LabResultRecord', 'MedicationRecord', 'ProcedureRecord', 'VitalSignRecord']
 }
 ```
 


### PR DESCRIPTION
The clinical record type `VitalSignRecord` was missing from the list of possible types.
