### PR TITLE
feat: AppleHealthKit.saveWalkingRunningDistance

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.h
@@ -14,6 +14,7 @@
 - (void)fitness_getSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_getDailyStepSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_saveSteps:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)fitness_saveWalkingRunningDistance:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_initializeStepEventObserver:(NSDictionary *)input hasListeners:(bool)hasListeners callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_getDistanceWalkingRunningOnDay:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)fitness_getDailyDistanceWalkingRunningSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -152,6 +152,32 @@
     }];
 }
 
+- (void)fitness_saveWalkingRunningDistance:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    double distance = [RCTAppleHealthKit doubleValueFromOptions:input];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit meterUnit]];
+
+    if(startDate == nil || endDate == nil){
+        callback(@[RCTMakeError(@"startDate and endDate are required in options", nil, nil)]);
+        return;
+    }
+
+    HKQuantity *quantity = [HKQuantity quantityWithUnit:unit doubleValue:distance];
+    HKQuantityType *type = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceWalkingRunning];
+    HKQuantitySample *sample = [HKQuantitySample quantitySampleWithType:type quantity:quantity startDate:startDate endDate:endDate];
+
+    [self.healthStore saveObject:sample withCompletion:^(BOOL success, NSError *error) {
+        if (!success) {
+            callback(@[RCTJSErrorFromNSError(error)]);
+            return;
+        }
+        callback(@[[NSNull null], @(distance)]);
+    }];
+}
+
+
 
 - (void)fitness_initializeStepEventObserver:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -237,6 +237,12 @@ RCT_EXPORT_METHOD(saveSteps:(NSDictionary *)input callback:(RCTResponseSenderBlo
     [self fitness_saveSteps:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(saveWalkingRunningDistance:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self fitness_saveWalkingRunningDistance:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getDistanceWalkingRunning:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ they are splitted in the following categories
 - [getDailyFlightsClimbedSamples](/docs/getDailyFlightsClimbedSamples.md)
 - [getFlightsClimbed](/docs/getFlightsClimbed.md)
 - [saveSteps](/docs/saveSteps.md)
+- [saveWalkingRunningDistance](/docs/saveWalkingRunningDistance.md)
 
 ### Hearing Methods
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -71,6 +71,7 @@
 * [getDailyFlightsClimbedSamples](/docs/getDailyFlightsClimbedSamples.md)
 * [getFlightsClimbed](/docs/getFlightsClimbed.md)
 * [saveSteps](/docs/saveSteps.md)
+- [saveWalkingRunningDistance](/docs/saveWalkingRunningDistance.md)
 
 ## Hearing Methods
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ There is a gitbook version for the documentation on this [link](https://vinicius
 - [getDailyFlightsClimbedSamples](getDailyFlightsClimbedSamples.md)
 - [getFlightsClimbed](getFlightsClimbed.md)
 - [saveSteps](saveSteps.md)
+- [saveWalkingRunningDistance](/docs/saveWalkingRunningDistance.md)
 
 ### Hearing Methods
 

--- a/docs/saveWalkingRunningDistance.md
+++ b/docs/saveWalkingRunningDistance.md
@@ -1,0 +1,36 @@
+# saveWalkingRunningDistance
+
+Save a walking + running distance sample.
+
+A distance sample represents the amount traveled during a specific period of time. A sample should be a precise as possible, with `startDate` and `endDate` representing the range of time the steps were taken in. The unit of distance can be specified by `units` key in `options` below, defaulting to meters.
+
+Example input options:
+
+```javascript
+// 300m over 5 min ~= 1 m/s (walking speed)
+let options = {
+  value: 300, // meters (default)
+  startDate: new Date(2022, 6, 11, 6, 0, 0).toISOString(),
+  endDate: new Date(2016, 6, 11, 6, 5, 0).toISOString(),
+}
+```
+
+Call the method:
+
+```javascript
+AppleHealthKit.saveWalkingRunningDistance(
+  (options: HealthInputOptions),
+  (err: Object, results: number) => {
+    if (this._handleHKError(err, 'saveWalkingRunningDistance')) {
+      return
+    }
+    // walking + running distance sample successfully saved
+  },
+)
+```
+
+Example output:
+
+```json
+300
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -152,6 +152,11 @@ declare module 'react-native-health' {
       callback: (error: string, result: HealthValue) => void,
     ): void
 
+    saveWalkingRunningDistance(
+      options: HealthValueOptions,
+      callback: (error: string, result: HealthValue) => void,
+    ): void
+
     getDistanceWalkingRunning(
       options: HealthInputOptions,
       callback: (err: string, results: HealthValue) => void,


### PR DESCRIPTION
## Description

Currently there is no way to log walking + running distance activity. In order to log distance while running I've added this new method which is modeled after the other write functions such as `saveWeight` and `saveSteps`. I've verified it works as expected as well.


https://user-images.githubusercontent.com/290084/178244181-39c1bc98-3d2a-434a-9b1d-a9748b5d9c2b.mp4



## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
