### PR TITLE
Updates the @expo/config-plugins version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "react-native": ">=0.40.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^2.0.0"
+    "@expo/config-plugins": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Description

Bumps the [@expo/config-plugins](https://www.npmjs.com/package/@expo/config-plugins) to the latest version. The version currently used depends on a version of [@xmldom/xmldom](https://www.npmjs.com/package/@xmldom/xmldom) (0.5.0) that is subject to a security advisory ([CVE-2021-32796](https://github.com/advisories/GHSA-5fg8-2547-mr8q)).

As far as I can tell there shouldn't be any backwards compatibility issues with the new version of `@expo/config-plugins` but I'm not an Expo expert.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
