### PR TITLE
Handle new sleep stage HKCategoryValues in iOS 16

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -614,6 +614,21 @@
                       case HKCategoryValueSleepAnalysisAsleep:
                         valueString = @"ASLEEP";
                       break;
+
+                      // watchOS 9 and iOS 16 introduce Core, Deep, REM, and Awake phases of sleep.
+                      case HKCategoryValueSleepAnalysisAsleepCore:
+                        valueString = @"CORE";
+                      break;
+                      case HKCategoryValueSleepAnalysisAsleepDeep:
+                        valueString = @"DEEP";
+                      break;
+                      case HKCategoryValueSleepAnalysisAsleepREM:
+                        valueString = @"REM";
+                      break;
+                      case HKCategoryValueSleepAnalysisAwake:
+                        valueString = @"AWAKE";
+                      break;
+
                      default:
                         valueString = @"UNKNOWN";
                      break;

--- a/docs/getSleepSamples.md
+++ b/docs/getSleepSamples.md
@@ -3,9 +3,10 @@
 Query for sleep samples.
 
 Each sleep sample represents a period of time with a startDate and an endDate.
-the sample's value will be either `INBED` or `ASLEEP`. these values should overlap,
-meaning that two (or more) samples represent a single nights sleep activity. see
-[Healthkit SleepAnalysis] reference documentation
+the sample's value will be either `INBED`, `ASLEEP`, or a sleep stage (`DEEP`,
+`CORE`, `REM`). In bed and sleeping samples should overlap, meaning that two
+(or more) samples represent a single nights sleep activity. See
+[Healthkit SleepAnalysis] reference documentation.
 
 The options object is used to setup a query to retrieve relevant samples.
 The options must contain `startDate` and may also optionally include `endDate`, `ascending`, or `limit` options


### PR DESCRIPTION
## Description

Sleep samples on iOS 16.0 (released Monday) are currently showing up with an UNKNOWN value.

This is because iOS 16 and watchOS 9 introduced sleep stages. Users with Apple Watches who have upgraded to the latest version of iOS will no longer see sleep samples with an HKCategoryValueSleepAnalysisAsleep value -- instead they will see many different sleep samples with HKCategoryValueSleepAnalysisAsleepCore, HKCategoryValueSleepAnalysisAsleepDeep, HKCategoryValueSleepAnalysisAsleepREM, or HKCategoryValueSleepAnalysisAwake values. In the current code, these are all mapped to UNKNOWN.

This PR adds support for the new support for CORE/DEEP/REM/AWAKE sleepAnalysis types, while retaining support for ASLEEP (for any users on iOS 15 or previous, or with other wearables). It also updates the relevant documentation.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
