### PR TITLE
feat: add HK RunningSpeed to permissions

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -81,6 +81,30 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleStandTime];
     } else if ([@"AppleExerciseTime" isEqualToString: key] && systemVersion >= 9.3) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierAppleExerciseTime];
+    } else if ([@"RunningPower" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningPower];
+        } else {
+            return nil;
+        }
+    } else if ([@"RunningStrideLength" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningStrideLength];
+        } else {
+            return nil;
+        }
+    } else if ([@"RunningVerticalOscillation" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningVerticalOscillation];
+        } else {
+            return nil;
+        }
+    } else if ([@"RunningGroundContactTime" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningGroundContactTime];
+        } else {
+            return nil;
+        }
     }
 
     // Nutrition Identifiers
@@ -282,6 +306,30 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierActiveEnergyBurned];
     } else if ([@"FlightsClimbed" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierFlightsClimbed];
+    } else if ([@"RunningPower" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningPower];
+        } else {
+            return nil;
+        }
+    } else if ([@"RunningStrideLength" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningStrideLength];
+        } else {
+            return nil;
+        }
+    } else if ([@"RunningVerticalOscillation" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningVerticalOscillation];
+        } else {
+            return nil;
+        }
+    } else if ([@"RunningGroundContactTime" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningGroundContactTime];
+        } else {
+            return nil;
+        }
     }
 
     // Nutrition Identifiers

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -59,6 +59,12 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierStepCount];
     } else if ([@"DistanceWalkingRunning" isEqualToString: key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceWalkingRunning];
+    } else if ([@"RunningSpeed" isEqualToString: key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningSpeed];
+        } else {
+            return nil;
+        }
     } else if ([@"DistanceCycling" isEqualToString: key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceCycling];
     } else if ([@"DistanceSwimming" isEqualToString: key]) {
@@ -260,6 +266,12 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierStepCount];
     } else if ([@"DistanceWalkingRunning" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceWalkingRunning];
+    } else if ([@"RunningSpeed" isEqualToString:key]) {
+        if (@available(iOS 16.0, *)) {
+            return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierRunningSpeed];
+        } else {
+            return nil;
+        }
     } else if ([@"DistanceCycling" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceCycling];
     } else if ([@"DistanceSwimming" isEqualToString:key]) {
@@ -370,7 +382,11 @@
     
     // Workout Route
     if ([@"WorkoutRoute" isEqualToString:key]) {
-        return [HKSeriesType workoutRouteType];
+        if (@available(iOS 11.0, *)) {
+            return [HKSeriesType workoutRouteType];
+        } else {
+            return nil;
+        }
     }
 
     // Lab and tests

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare module 'react-native-health' {
   }
 
   export interface HKErrorResponse {
-    message?: string;
+    message?: string
   }
 
   export interface AppleHealthKit {
@@ -465,10 +465,10 @@ declare module 'react-native-health' {
   }
 
   export interface HeartbeatSeriesSampleValue extends BaseValue {
-    heartbeatSeries: ({
+    heartbeatSeries: {
       timeSinceSeriesStart: number
       precededByGap: boolean
-    })[]
+    }[]
   }
 
   export interface HealthUnitOptions {
@@ -513,15 +513,13 @@ declare module 'react-native-health' {
     end: string
   }
 
-
-
   export interface ElectrocardiogramSampleValue extends BaseValue {
-    classification: ElectrocardiogramClassification,
-    averageHeartRate: number,
-    samplingFrequency: number,
-    device: string,
-    algorithmVersion: number,
-    voltageMeasurements: (number[])[]
+    classification: ElectrocardiogramClassification
+    averageHeartRate: number
+    samplingFrequency: number
+    device: string
+    algorithmVersion: number
+    voltageMeasurements: number[][]
   }
 
   export interface HealthValueOptions extends HealthUnitOptions {
@@ -565,14 +563,14 @@ declare module 'react-native-health' {
     LabResultRecord = 'LabResultRecord',
     MedicationRecord = 'MedicationRecord',
     ProcedureRecord = 'ProcedureRecord',
-    VitalSignRecord = 'VitalSignRecord'
+    VitalSignRecord = 'VitalSignRecord',
   }
 
   export interface HealthClinicalRecord extends BaseValue {
-    sourceName: string,
-    sourceId: string,
-    displayName: string,
-    fhirData: any,
+    sourceName: string
+    sourceId: string
+    displayName: string
+    fhirData: any
   }
 
   /* Health Constants */
@@ -746,7 +744,8 @@ declare module 'react-native-health' {
     WalkingHeartRateAverage = 'WalkingHeartRateAverage',
     Weight = 'Weight',
     Workout = 'Workout',
-    WorkoutRoute = 'WorkoutRoute'
+    WorkoutRoute = 'WorkoutRoute',
+    RunningSpeed = 'RunningSpeed',
   }
 
   export enum HealthUnit {

--- a/index.d.ts
+++ b/index.d.ts
@@ -746,6 +746,10 @@ declare module 'react-native-health' {
     Workout = 'Workout',
     WorkoutRoute = 'WorkoutRoute',
     RunningSpeed = 'RunningSpeed',
+    RunningPower = 'RunningPower',
+    RunningStrideLength = 'RunningStrideLength',
+    RunningVerticalOscillation = 'RunningVerticalOscillation',
+    RunningGroundContactTime = 'RunningGroundContactTime',
   }
 
   export enum HealthUnit {

--- a/src/constants/Permissions.js
+++ b/src/constants/Permissions.js
@@ -93,4 +93,8 @@ export const Permissions = {
   Workout: 'Workout',
   WorkoutRoute: 'WorkoutRoute',
   RunningSpeed: 'RunningSpeed',
+  RunningPower: 'RunningPower',
+  RunningStrideLength: 'RunningStrideLength',
+  RunningVerticalOscillation: 'RunningVerticalOscillation',
+  RunningGroundContactTime: 'RunningGroundContactTime',
 }

--- a/src/constants/Permissions.js
+++ b/src/constants/Permissions.js
@@ -5,7 +5,7 @@
  */
 export const Permissions = {
   ActiveEnergyBurned: 'ActiveEnergyBurned',
-  ActivitySummary: "ActivitySummary",
+  ActivitySummary: 'ActivitySummary',
   AllergyRecord: 'AllergyRecord',
   AppleExerciseTime: 'AppleExerciseTime',
   AppleStandTime: 'AppleStandTime',
@@ -91,5 +91,6 @@ export const Permissions = {
   WalkingHeartRateAverage: 'WalkingHeartRateAverage',
   Weight: 'Weight',
   Workout: 'Workout',
-  WorkoutRoute: 'WorkoutRoute'
+  WorkoutRoute: 'WorkoutRoute',
+  RunningSpeed: 'RunningSpeed',
 }


### PR DESCRIPTION
## Description

We use react-native-health to ask users to accept HK permissions of metrics that we use in our Apple Watch app. In WatchOS9 'RunningSpeed' was released which will return the pace of the user while running outside. This PR exposes the new metric to the Permissions module of this library

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
