### PR TITLE
docs: fix getSamples method docs hyperlink

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ There is a gitbook version for the documentation on this [link](https://vinicius
 
 - [getDailyStepCountSamples](getDailyStepCountSamples.md)
 - [getStepCount](getStepCount.md)
-- [getSamples](docs/getSamples.md)
+- [getSamples](getSamples.md)
 - [getDailyDistanceWalkingRunningSamples](getDailyDistanceWalkingRunningSamples.md)
 - [getDistanceWalkingRunning](getDistanceWalkingRunning.md)
 - [getDailyDistanceSwimmingSamples](getDailyDistanceSwimmingSamples.md)


### PR DESCRIPTION
## Description

Current hyperlink doubles /docs and points to non-existing file

Fixes # (issue)

Typo edited

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
