### PR TITLE
Workout Events and Duration To getAnchoredWorkouts Method

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -515,6 +515,8 @@
                         double energy =  [[sample totalEnergyBurned] doubleValueForUnit:[HKUnit kilocalorieUnit]];
                         double distance = [[sample totalDistance] doubleValueForUnit:[HKUnit mileUnit]];
                         NSString *type = [RCTAppleHealthKit stringForHKWorkoutActivityType:[sample workoutActivityType]];
+                        NSArray *workoutEvents = [RCTAppleHealthKit formatWorkoutEvents:[sample workoutEvents]];
+                        NSTimeInterval duration = [sample duration];
 
                         NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
                         NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
@@ -546,7 +548,9 @@
                                                @"device": device,
                                                @"distance" : @(distance),
                                                @"start" : startDateString,
-                                               @"end" : endDateString
+                                               @"end" : endDateString,
+                                               @"duration": @(duration),
+                                               @"workoutEvents": workoutEvents
                                                };
 
                         [data addObject:elem];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.h
@@ -37,7 +37,7 @@ extern NSString * const kMetadataKey;
 + (HKWorkoutActivityType)hkWorkoutActivityTypeFromOptions: (NSDictionary *)options key: (NSString *)key withDefault: (HKWorkoutActivityType)defaultValue;
 + (HKQuantity *)hkQuantityFromOptions:(NSDictionary *)options valueKey: (NSString *)valueKey unitKey: (NSString *)unitKey;
 + (NSDictionary *)metadataFromOptions:(NSDictionary *)options withDefault:(NSDictionary *)defaultValue;
-
++ (NSArray *)formatWorkoutEvents:(NSArray *)workoutEvents;
 + (NSMutableArray *)reverseNSMutableArray:(NSMutableArray *)array;
 + (NSString*) stringForHKWorkoutActivityType:(int) enumValue;
 

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -15,6 +15,55 @@ NSString * const kMetadataKey = @"metadata";
 
 #pragma mark - Utilities
 
++ (NSArray *)formatWorkoutEvents:(NSArray *)workoutEvents
+{
+    NSMutableArray *formattedWorkEvents = [[NSMutableArray alloc] init];
+    
+    for (id workoutEvent in workoutEvents) {
+        NSNumber *eventType = [workoutEvent valueForKey:@"type"];
+        NSString *eventDescription = @"";
+        
+        switch([eventType intValue]) {
+            case (int)HKWorkoutEventTypePause:
+                eventDescription = @"pause";
+                break;
+            case (int)HKWorkoutEventTypeResume:
+                eventDescription = @"resume";
+                break;
+            case (int)HKWorkoutEventTypeMotionPaused:
+                eventDescription = @"motion paused";
+                break;
+            case (int)HKWorkoutEventTypeMotionResumed:
+                eventDescription = @"motion resumed";
+                break;
+            case (int)HKWorkoutEventTypePauseOrResumeRequest:
+                eventDescription = @"pause or resume request";
+                break;
+            case (int)HKWorkoutEventTypeLap:
+                eventDescription = @"lap";
+                break;
+            case (int)HKWorkoutEventTypeSegment:
+                eventDescription = @"segment";
+                break;
+            case (int)HKWorkoutEventTypeMarker:
+                eventDescription = @"marker";
+            default:
+                eventDescription = @"";
+        }
+        
+        
+        NSObject *formattedEvent = @{
+            @"eventTypeInt":eventType,
+            @"eventType": eventDescription,
+            @"startDate": [RCTAppleHealthKit buildISO8601StringFromDate:[[workoutEvent dateInterval] startDate]],
+            @"endDate": [RCTAppleHealthKit buildISO8601StringFromDate:[[workoutEvent dateInterval] endDate]]
+        };
+        [formattedWorkEvents addObject: formattedEvent];
+    }
+    
+    return formattedWorkEvents;
+}
+
 + (NSDate *)parseISO8601DateFromString:(NSString *)date
 {
     @try {

--- a/docs/getAnchoredWorkouts.md
+++ b/docs/getAnchoredWorkouts.md
@@ -59,5 +59,12 @@ The resulting workouts in the array will look as the following:
   distance: Number, // [[sample totalDistance] doubleValueForUnit:[HKUnit mileUnit]]
   start: String, // [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate];
   end: String, // [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
+  duration: Number, // NSTimeInterval (seconds)
+  workoutEvents: {
+    endDate: String, // [RCTAppleHealthKit buildISO8601StringFromDate:sample.endDate];
+    startDate: String, // [RCTAppleHealthKit buildISO8601StringFromDate:sample.startDate]
+    eventTypeInt: Number,
+    eventType: String, // EventType enum
+  }[]
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -498,11 +498,22 @@ declare module 'react-native-health' {
     locations: LocationValue[]
   }
 
+  export enum EventType {
+    Pause = 'pause',
+    Resume = 'resume',
+    MotionPaused = 'motion paused',
+    MotionResumed = 'motion resumed',
+    PausedOrResumeRequest = 'pause or resume request',
+    Lap = 'lap',
+    Segment = 'segment',
+    Marker = 'marker'
+  }
+
   export type HKWorkoutEventType = {
     endDate: string
     startDate: string
     eventTypeInt: number
-    eventType: string
+    eventType: EventType
   }
 
   export interface HKWorkoutQueriedSampleType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -498,6 +498,13 @@ declare module 'react-native-health' {
     locations: LocationValue[]
   }
 
+  export type HKWorkoutEventType = {
+    endDate: string
+    startDate: string
+    eventTypeInt: number
+    eventType: string
+  }
+
   export interface HKWorkoutQueriedSampleType {
     activityId: number
     activityName: string
@@ -511,6 +518,8 @@ declare module 'react-native-health' {
     distance: number
     start: string
     end: string
+    duration: number
+    workoutEvents: HKWorkoutEventType[]
   }
 
 


### PR DESCRIPTION
## Description

Adding duration and workout events to the response of the `getAnchoredWorkouts()` method.

- Duration returns the total duration covering all the samples that match the query.
- Workout events return's an array with multiple attributes like when the user has paused and/or resumed a workout.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
