### PR TITLE
Fix: Crash when getting statistical data without permissions

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m
@@ -35,7 +35,7 @@
                                     includeManuallyAdded:includeManuallyAdded
                                     day:date
                              completion:^(double value, NSDate *startDate, NSDate *endDate, NSError *error) {
-        if (!value && value != 0) {
+        if ((!value && value != 0) || error != nil) {
             callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
@@ -218,7 +218,7 @@
     HKQuantityType *quantityType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceWalkingRunning];
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit includeManuallyAdded:includeManuallyAdded day:date completion:^(double distance, NSDate *startDate, NSDate *endDate, NSError *error) {
-        if (!distance && distance != 0) {
+        if ((!distance && distance != 0) || error != nil) {
             callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
@@ -277,7 +277,7 @@
     HKQuantityType *quantityType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceSwimming];
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit includeManuallyAdded:includeManuallyAdded day:date completion:^(double distance, NSDate *startDate, NSDate *endDate, NSError *error) {
-        if (!distance && distance != 0) {
+        if ((!distance && distance != 0) || error != nil) {
             callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
@@ -334,7 +334,7 @@
     HKQuantityType *quantityType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDistanceCycling];
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit includeManuallyAdded:includeManuallyAdded day:date completion:^(double distance, NSDate *startDate, NSDate *endDate, NSError *error) {
-        if (!distance && distance != 0) {
+        if ((!distance && distance != 0) || error != nil) {
             callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }
@@ -391,7 +391,7 @@
     HKQuantityType *quantityType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierFlightsClimbed];
 
     [self fetchSumOfSamplesOnDayForType:quantityType unit:unit includeManuallyAdded:includeManuallyAdded day:date completion:^(double count, NSDate *startDate, NSDate *endDate, NSError *error) {
-        if (!count && count != 0) {
+        if ((!count && count != 0) || error != nil) {
             callback(@[RCTJSErrorFromNSError(error)]);
             return;
         }

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -756,6 +756,12 @@
                                                                     NSDate *startDate = result.startDate;
                                                                     NSDate *endDate = result.endDate;
                                                                     double value = [sum doubleValueForUnit:unit];
+                                                                    if (startDate == nil || endDate == nil) {
+                                                                        error = [[NSError alloc] initWithDomain:@"AppleHealthKit"
+                                                                                                           code:0
+                                                                                                           userInfo:@{@"Error reason": @"Could not fetch statistics: Not authorized"}
+                                                                        ];
+                                                                    }
                                                                     completionHandler(value, startDate, endDate, error);
                                                               }
                                                           }];


### PR DESCRIPTION
## Description

Lib currently crashes when trying to get statistical data without user permission. This happens because `startDate` and `endDate` fields on the query's response are `null` in this case, and the code crashes when trying to add them to an NSDictionary. Fixed by returning an error to js.

Fixes #97

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
