### PR TITLE
added expo support to `NSHealthClinicalHealthRecordsShareUsageDescription` 

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -2,10 +2,11 @@ const { withEntitlementsPlist, withInfoPlist } = require('@expo/config-plugins')
 
 const HEALTH_SHARE = 'Allow $(PRODUCT_NAME) to check health info'
 const HEALTH_UPDATE = 'Allow $(PRODUCT_NAME) to update health info'
+const HEALTH_CLINIC_SHARE = 'Allow $(PRODUCT_NAME) to check health clinical info'
 
 const withHealthKit = (
   config,
-  { healthSharePermission, healthUpdatePermission, isClinicalDataEnabled } = {},
+  { healthSharePermission, healthUpdatePermission, isClinicalDataEnabled, healthClinicalDescription } = {},
 ) => {
   // Add permissions
   config = withInfoPlist(config, (config) => {
@@ -17,6 +18,12 @@ const withHealthKit = (
       healthUpdatePermission ||
       config.modResults.NSHealthUpdateUsageDescription ||
       HEALTH_UPDATE
+    isClinicalDataEnabled ?
+      config.modResults.NSHealthClinicalHealthRecordsShareUsageDescription =
+        healthClinicalDescription ||
+        config.modResults.NSHealthClinicalHealthRecordsShareUsageDescription ||
+        HEALTH_CLINIC_SHARE :
+      null
 
     return config
   })

--- a/docs/Expo.md
+++ b/docs/Expo.md
@@ -27,6 +27,7 @@ The plugin provides props for extra customization. Every time you change the pro
 - `healthSharePermission` (_string_): Sets the iOS `NSHealthShareUsageDescription` permission message to the `Info.plist`. Defaults to `Allow $(PRODUCT_NAME) to check health info`.
 - `healthUpdatePermission` (_string_): Sets the iOS `NSHealthUpdateUsageDescription` permission message to the `Info.plist`. Defaults to `Allow $(PRODUCT_NAME) to update health info`.
 - `isClinicalDataEnabled` (_boolean_): Adds `health-records` to the `com.apple.developer.healthkit.access` entitlement in the iOS project. Defaults to false.
+- `healthClinicalDescription` (_string_): Sets the iOS `NSHealthClinicalHealthRecordsShareUsageDescription` permission message to the `Info.plist`. Defaults to `Allow $(PRODUCT_NAME) to check health info`.
 
 `app.config.js`
 
@@ -39,7 +40,8 @@ The plugin provides props for extra customization. Every time you change the pro
         {
           "isClinicalDataEnabled": true,
           "healthSharePermission": "Custom health share permission",
-          "healthUpdatePermission": "Custom health update permission"
+          "healthUpdatePermission": "Custom health update permission",
+          "healthClinicalDescription": "Custom health share permission for clinical data"
         }
       ]
     ]


### PR DESCRIPTION
## Description

The expo plugin doesn't have support for `NSHealthClinicalHealthRecordsShareUsageDescription`, so I added the support to also modify that from `app.config.js` 

I've also tested that the Info.plist has been modified correctly after running `expo prebuild`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
