### PR TITLE
Add getFiberSamples

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.h
@@ -18,5 +18,6 @@
 
 - (void)dietary_getEnergyConsumedSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)dietary_getProteinSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)dietary_getFiberSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)dietary_getTotalFatSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Dietary.m
@@ -108,6 +108,37 @@
     }];
 }
 
+- (void)dietary_getFiberSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *fiberType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryFiber];
+    HKUnit *unit = [RCTAppleHealthKit hkUnitFromOptions:input key:@"unit" withDefault:[HKUnit gramUnit]];
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+    NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+
+    [self fetchQuantitySamplesOfType:fiberType
+                                unit:unit
+                           predicate:predicate
+                           ascending:ascending
+                               limit:limit
+                          completion:^(NSArray *results, NSError *error) {
+        if(results){
+            callback(@[[NSNull null], results]);
+            return;
+        } else {
+            NSLog(@"An error occured while retrieving the fiber sample %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while retrieving the fiber sample", error, nil)]);
+            return;
+        }
+    }];
+}
+
 - (void)saveFood:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     NSString *foodNameValue = [RCTAppleHealthKit stringFromOptions:input key:@"foodName" withDefault:nil];

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -335,6 +335,11 @@ RCT_EXPORT_METHOD(getProteinSamples:(NSDictionary *)input callback:(RCTResponseS
    [self dietary_getProteinSamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getFiberSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+   [self dietary_getFiberSamples:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(getTotalFatSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
    [self dietary_getTotalFatSamples:input callback:callback];

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This package allows access to health & fitness data exposed by Apple Healthkit. 
 
 If you are looking for a more robust solution providing normalized data, insights and recommendations based on user's biometric data, data from multiple sources (Fitbit, Oura), or a hosted solution, please check out the [Point SDK](https://www.areyouonpoint.co/) developed by our frens.
 
-
 # Discord
+
 <a href="https://discord.gg/d24g5XDePr"><img src="https://img.shields.io/badge/Discord-join%20chat-738bd7.svg" alt="React Native Health official Discord"></a>
 
 ## Getting Started
@@ -200,6 +200,7 @@ All the documentation is under the [docs](/docs) folder. They are split into the
 
 - [getEnergyConsumedSamples](/docs/getEnergyConsumedSamples.md)
 - [getProteinSamples](/docs/getProteinSamples.md)
+- [getFiberSamples](/docs/getFiberSamples.md)
 - [getTotalFatSamples](/docs/getTotalFatSamples.md)
 - [saveFood](/docs/saveFood.md)
 - [saveWater](/docs/saveWater.md)

--- a/docs/getFiberSamples.md
+++ b/docs/getFiberSamples.md
@@ -1,0 +1,46 @@
+# getFiberSamples
+
+A quantity sample type that measures the amount of fiber consumed.
+
+Permission required:
+
+- `AppleHealthKit.Constants.Permissions.Fiber`
+
+Example input options:
+
+```javascript
+let options = {
+  startDate: new Date(2021, 0, 0).toISOString(), // required
+  endDate: new Date().toISOString(), // optional; default now
+}
+```
+
+Call the method:
+
+```javascript
+AppleHealthKit.getFiberSamples(
+  (options: HealthInputOptions),
+  (err: Object, results: HealthValue) => {
+    if (err) {
+      return
+    }
+    console.log(results)
+  },
+)
+```
+
+Example output:
+
+```json
+[
+  {
+    "id": "5013eca7-4aee-45af-83c1-dbe3696b2e51", // The universally unique identifier (UUID) for this HealthKit object.
+    "endDate": "2021-04-01T22:00:00.000+0300",
+    "startDate": "2021-04-01T22:00:00.000+0300",
+    "value": 39,
+    "metadata": {
+      "HKWasUserEntered": true
+    }
+  }
+]
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare module 'react-native-health' {
   }
 
   export interface HKErrorResponse {
-    message?: string;
+    message?: string
   }
 
   export interface AppleHealthKit {
@@ -206,6 +206,11 @@ declare module 'react-native-health' {
     ): void
 
     getProteinSamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+    getFiberSamples(
       options: HealthInputOptions,
       callback: (err: string, results: Array<HealthValue>) => void,
     ): void
@@ -478,10 +483,10 @@ declare module 'react-native-health' {
   }
 
   export interface HeartbeatSeriesSampleValue extends BaseValue {
-    heartbeatSeries: ({
+    heartbeatSeries: {
       timeSinceSeriesStart: number
       precededByGap: boolean
-    })[]
+    }[]
   }
 
   export interface HealthUnitOptions {
@@ -526,15 +531,13 @@ declare module 'react-native-health' {
     end: string
   }
 
-
-
   export interface ElectrocardiogramSampleValue extends BaseValue {
-    classification: ElectrocardiogramClassification,
-    averageHeartRate: number,
-    samplingFrequency: number,
-    device: string,
-    algorithmVersion: number,
-    voltageMeasurements: (number[])[]
+    classification: ElectrocardiogramClassification
+    averageHeartRate: number
+    samplingFrequency: number
+    device: string
+    algorithmVersion: number
+    voltageMeasurements: number[][]
   }
 
   export interface HealthValueOptions extends HealthUnitOptions {
@@ -578,14 +581,14 @@ declare module 'react-native-health' {
     LabResultRecord = 'LabResultRecord',
     MedicationRecord = 'MedicationRecord',
     ProcedureRecord = 'ProcedureRecord',
-    VitalSignRecord = 'VitalSignRecord'
+    VitalSignRecord = 'VitalSignRecord',
   }
 
   export interface HealthClinicalRecord extends BaseValue {
-    sourceName: string,
-    sourceId: string,
-    displayName: string,
-    fhirData: any,
+    sourceName: string
+    sourceId: string
+    displayName: string
+    fhirData: any
   }
 
   /* Health Constants */
@@ -760,7 +763,7 @@ declare module 'react-native-health' {
     WalkingHeartRateAverage = 'WalkingHeartRateAverage',
     Weight = 'Weight',
     Workout = 'Workout',
-    WorkoutRoute = 'WorkoutRoute'
+    WorkoutRoute = 'WorkoutRoute',
   }
 
   export enum HealthUnit {


### PR DESCRIPTION
## Description

This PR adds support for getting `fiber` values the same way as getting e.g. `protein`. Also the `README.md` was updated and docs added for the new `fiber` support.

Fixes #273

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
