### PR TITLE
Get Energy Doc Fixes

### DIFF
--- a/docs/getActiveEnergyBurned.md
+++ b/docs/getActiveEnergyBurned.md
@@ -1,6 +1,6 @@
 # getActiveEnergyBurned
 
-A quantity sample type that measures the amount of active energy the user has burned.
+A quantity sample type that measures the amount of `active energy` the user has burned within a period of time.
 
 Example input options:
 
@@ -8,6 +8,8 @@ Example input options:
 let options = {
   startDate: new Date(2021, 0, 0).toISOString(), // required
   endDate: new Date().toISOString(), // optional; default now
+  ascending: true, // optional
+  includeManuallyAdded: true, // optional
 }
 ```
 

--- a/docs/getActiveEnergyBurned.md
+++ b/docs/getActiveEnergyBurned.md
@@ -1,6 +1,6 @@
 # getActiveEnergyBurned
 
-A quantity sample type that measures the amount of `active energy` the user has burned within a period of time.
+A quantity sample type that measures the amount of `active energy` the user has burned within a period of time. This represents only the Active Kilocalories from the Total Kilocalories for that time period.
 
 Example input options:
 

--- a/docs/getBasalEnergyBurned.md
+++ b/docs/getBasalEnergyBurned.md
@@ -1,6 +1,7 @@
 # getBasalEnergyBurned
 
-A quantity sample type that measures the amount of energy burned.
+A quantity sample type that measures the amount of `resting energy` burned for within a period of time.
+These samples together with active energy burned for the same time period represent the `total energy` burned for that period (usually seen as Total Kilocalories in workout on Apple Watch).
 
 Example input options:
 
@@ -8,6 +9,8 @@ Example input options:
 let options = {
   startDate: new Date(2018, 10, 1).toISOString(), // required
   endDate: new Date().toISOString(), // optional; default now
+  ascending: true, // optional
+  includeManuallyAdded: true, // optional
 }
 ```
 

--- a/docs/getBasalEnergyBurned.md
+++ b/docs/getBasalEnergyBurned.md
@@ -1,7 +1,7 @@
 # getBasalEnergyBurned
 
-A quantity sample type that measures the amount of `resting energy` burned for within a period of time.
-These samples together with active energy burned for the same time period represent the `total energy` burned for that period (usually seen as Total Kilocalories in workout on Apple Watch).
+A quantity sample type that measures the amount of `resting energy` burned within a period of time.
+These samples together with `active energy` burned for the same time period represent the `total energy` burned for that period (usually seen as Total Kilocalories in a workout on Apple Watch).
 
 Example input options:
 


### PR DESCRIPTION
## Description

I and some of my colleagues used this library to get user's calories for a specific time period as we want to record people's workouts in our app. The problem that we faced was that we could not get the Total Calories from an Apple Watch workout. The description of getActiveEnergyBurned and getBasalEnergyBurned in docs were the same, so not knowing what 'basal' means we kind of ignored it. We wanted to obtain the total calories which is the sum of the two but were pointed on the wrong track due to the wording of the docs. I am sure others have had the same confusion and thus I wanted to improve the docs a little bit so that other people figure out faster the idea of active, resting and total calories.

Also, I added some of the options we needed but again, didn't know existed at the beginning (figured out waaay later) as that meant looking into the library for interfaces, it is not obvious especially for javascript files that do not support interfaces. I hope this might help people understand the library faster and not spend time looking everywhere for answers.

Side note, most people use typescript these days, so I think it would be very beneficial if the docs were rewritten with the necessary interfaces, such as the `options` variable in my PR (I did not add the interface since it would not be consistent with the docs). People using typescript can import it and javascript users know what to look for to see the content of the interfaces. So if someone is willing to do that and if who's reviewing the PRs agrees, I think that would be very helpful.

## Checklist:

- [+] I have made corresponding changes to the documentation
- [+] I have checked my code and corrected any misspellings
