### PR TITLE
docs: Update Expo.md

### DIFF
--- a/docs/Expo.md
+++ b/docs/Expo.md
@@ -1,8 +1,8 @@
 # Expo installation
 
-> This package cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
+> This package cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.dev/workflow/customizing/).
 
-First install the package with yarn, npm, or [`expo install`](https://docs.expo.io/workflow/expo-cli/#expo-install).
+First install the package with yarn, npm, or [`npx expo install`](https://docs.expo.dev/more/expo-cli/#installation).
 
 ```sh
 expo install react-native-health
@@ -18,7 +18,7 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 }
 ```
 
-Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
+Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.dev/workflow/customizing/) guide.
 
 ## API
 


### PR DESCRIPTION
## Description

Hi 👋

One thing I'd like to update and make it future-proof for Expo specific projects is to update the installation command from `expo install...` to `npx expo install...`. Since the latter refers to the new Expo CLI, which doesn't require any global package installation. For `expo install`, people will need to install the deprecated global cli (and we are not recommending that).

Also, update docs-related links.

Thank you!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
