### PR TITLE
Support for Insulin Delivery samples

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
@@ -11,6 +11,7 @@
 
 - (void)results_getBloodGlucoseSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)results_getCarbohydratesSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)results_getInsulinDeliverySamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)results_saveBloodGlucoseSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)results_saveCarbohydratesSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)results_deleteBloodGlucoseSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
@@ -17,5 +17,6 @@
 - (void)results_deleteBloodGlucoseSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
 - (void)results_deleteCarbohydratesSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
 - (void)results_saveInsulinDeliverySample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)results_registerObservers:(RCTBridge *)bridge hasListeners:(bool)hasListeners;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
@@ -16,5 +16,6 @@
 - (void)results_saveCarbohydratesSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)results_deleteBloodGlucoseSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
 - (void)results_deleteCarbohydratesSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
+- (void)results_saveInsulinDeliverySample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.h
@@ -17,6 +17,7 @@
 - (void)results_deleteBloodGlucoseSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
 - (void)results_deleteCarbohydratesSample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
 - (void)results_saveInsulinDeliverySample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)results_deleteInsulinDeliverySample:(NSString *)oid callback:(RCTResponseSenderBlock)callback;
 - (void)results_registerObservers:(RCTBridge *)bridge hasListeners:(bool)hasListeners;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -111,6 +111,34 @@
     }];
 }
 
+- (void)results_saveInsulinDeliverySample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *insulinDeliveryType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierInsulinDelivery];
+
+    HKUnit *unit = [HKUnit internationalUnit];
+
+    double value = [RCTAppleHealthKit doubleValueFromOptions:input];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:[NSDate date]];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:startDate];
+    NSDictionary *metadata = [RCTAppleHealthKit metadataFromOptions:input withDefault:nil];
+
+    HKQuantity *quantity = [HKQuantity quantityWithUnit:unit doubleValue:value];
+    HKQuantitySample *sample = [HKQuantitySample quantitySampleWithType:insulinDeliveryType
+                                                                      quantity:quantity
+                                                                     startDate:startDate
+                                                                       endDate:endDate
+                                                                      metadata:metadata];
+
+    [self.healthStore saveObject:sample withCompletion:^(BOOL success, NSError *error) {
+        if (!success) {
+            NSLog(@"An error occured while saving the insulin sample %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while saving the insulin sample", error, nil)]);
+            return;
+        }
+        callback(@[[NSNull null], [sample.UUID UUIDString]]);
+    }];
+}
+
 - (void)results_saveBloodGlucoseSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     HKQuantityType *bloodGlucoseType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -226,4 +226,12 @@
     }];
 }
 
+- (void)results_registerObservers:(RCTBridge *)bridge hasListeners:(bool)hasListeners
+{
+    if (@available(iOS 11.0, *)) {
+        HKSampleType* insulinType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierInsulinDelivery];
+        [self setObserverForType:insulinType type:@"InsulinDelivery" bridge:bridge hasListeners:hasListeners];
+    }
+}
+
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -226,6 +226,21 @@
     }];
 }
 
+- (void)results_deleteInsulinDeliverySample:(NSString *)oid callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *insulinDeliveryType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierInsulinDelivery];
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:oid];
+    NSPredicate *uuidPredicate = [HKQuery predicateForObjectWithUUID:uuid];
+    [self.healthStore deleteObjectsOfType:insulinDeliveryType predicate:uuidPredicate withCompletion:^(BOOL success, NSUInteger deletedObjectCount, NSError * _Nullable error) {
+        if (!success) {
+            NSLog(@"An error occured while deleting the insulin delivery sample %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while deleting the insulin delivery sample", error, nil)]);
+            return;
+        }
+        callback(@[[NSNull null], @(deletedObjectCount)]);
+    }];
+}
+
 - (void)results_registerObservers:(RCTBridge *)bridge hasListeners:(bool)hasListeners
 {
     if (@available(iOS 11.0, *)) {

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Results.m
@@ -46,6 +46,40 @@
     }];
 }
 
+- (void)results_getInsulinDeliverySamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
+{
+    HKQuantityType *insulinDeliveryType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierInsulinDelivery];
+
+    HKUnit *unit = [HKUnit internationalUnit];
+
+    NSUInteger limit = [RCTAppleHealthKit uintFromOptions:input key:@"limit" withDefault:HKObjectQueryNoLimit];
+    BOOL ascending = [RCTAppleHealthKit boolFromOptions:input key:@"ascending" withDefault:false];
+    NSDate *startDate = [RCTAppleHealthKit dateFromOptions:input key:@"startDate" withDefault:nil];
+    NSDate *endDate = [RCTAppleHealthKit dateFromOptions:input key:@"endDate" withDefault:[NSDate date]];
+    if(startDate == nil){
+        callback(@[RCTMakeError(@"startDate is required in options", nil, nil)]);
+        return;
+    }
+
+    NSPredicate * predicate = [RCTAppleHealthKit predicateForSamplesBetweenDates:startDate endDate:endDate];
+
+    [self fetchQuantitySamplesOfType:insulinDeliveryType
+                                unit:unit
+                           predicate:predicate
+                           ascending:ascending
+                               limit:limit
+                          completion:^(NSArray *results, NSError *error) {
+        if(results){
+            callback(@[[NSNull null], results]);
+            return;
+        } else {
+            NSLog(@"An error occured while retrieving the glucose sample %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while retrieving the glucose sample", error, nil)]);
+            return;
+        }
+    }];
+}
+
 - (void)results_getCarbohydratesSamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
 {
     HKQuantityType *carbohydratesType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryCarbohydrates];

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -158,6 +158,8 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryWater];
     } else if ([@"BloodGlucose" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];
+    } else if ([@"InsulinDelivery" isEqualToString:key]) {
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierInsulinDelivery];
     }
 
     // Vital Signs Identifiers

--- a/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+TypesAndPermissions.m
@@ -357,6 +357,8 @@
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryWater];
     } else if ([@"BloodGlucose" isEqualToString:key]) {
         return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierBloodGlucose];
+    } else if ([@"InsulinDelivery" isEqualToString:key]) {
+        return [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierInsulinDelivery];
     }
 
     // Sleep

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -472,6 +472,12 @@ RCT_EXPORT_METHOD(getCarbohydratesSamples:(NSDictionary *)input callback:(RCTRes
     [self results_getCarbohydratesSamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(getInsulinDeliverySamples:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self results_getInsulinDeliverySamples:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(saveCarbohydratesSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -680,7 +680,8 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
         @"MedicationRecord",
         @"ProcedureRecord",
         @"VitalSignRecord",
-        @"SleepAnalysis"
+        @"SleepAnalysis",
+        @"InsulinDelivery"
     ];
     
     NSArray *templates = @[@"healthKit:%@:new", @"healthKit:%@:failure", @"healthKit:%@:enabled", @"healthKit:%@:sample", @"healthKit:%@:setup:success", @"healthKit:%@:setup:failure"];
@@ -798,6 +799,8 @@ RCT_EXPORT_METHOD(getClinicalRecords:(NSDictionary *)input callback:(RCTResponse
         for(NSString * type in clinicalObservers) {
             [self clinical_registerObserver:type bridge:bridge hasListeners:hasListeners];
         }
+        
+        [self results_registerObservers:bridge hasListeners:hasListeners];
 
         NSLog(@"[HealthKit] Background observers added to the app");
         [self startObserving];

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -478,6 +478,12 @@ RCT_EXPORT_METHOD(getInsulinDeliverySamples:(NSDictionary *)input callback:(RCTR
     [self results_getInsulinDeliverySamples:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(saveInsulinDeliverySample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self results_saveInsulinDeliverySample:input callback:callback];
+}
+
 RCT_EXPORT_METHOD(saveCarbohydratesSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -484,6 +484,12 @@ RCT_EXPORT_METHOD(saveInsulinDeliverySample:(NSDictionary *)input callback:(RCTR
     [self results_saveInsulinDeliverySample:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(deleteInsulinDeliverySample:(NSString *)oid callback:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self results_deleteInsulinDeliverySample:oid callback:callback];
+}
+
 RCT_EXPORT_METHOD(saveCarbohydratesSample:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/docs/background.md
+++ b/docs/background.md
@@ -11,6 +11,7 @@ following:
 - `ActiveEnergyBurned`
 - `BasalEnergyBurned`
 - `Cycling`
+- `InsulinDelivery`
 - `HeartRate`
 - `HeartRateVariabilitySDNN`
 - `RestingHeartRate`

--- a/docs/deleteInsulinDeliverySample.md
+++ b/docs/deleteInsulinDeliverySample.md
@@ -1,0 +1,33 @@
+# deleteInsulinDeliverySample
+
+Delete a insulin delivery value from HealthKit.
+
+`deleteInsulinDeliverySample` accepts an record's UUID string and a callback:
+
+Example input object:
+
+```javascript
+let id = "A11E708A-63A4-42DF-B1E1-F5E2F88B6CA1"
+```
+
+Example usage:
+
+```javascript
+AppleHealthKit.deleteInsulinDeliverySample(
+    id,
+    (err: string, result: HealthValue) => {
+        if (err) {
+            console.log(err)
+            return
+        }
+        // sample successfully deleted
+      console.log(result)
+    },
+)
+```
+
+Example output (1 if deleted):
+
+```json
+1
+```

--- a/docs/getInsulinDeliverySamples.md
+++ b/docs/getInsulinDeliverySamples.md
@@ -1,0 +1,44 @@
+# getInsulinDeliverySamples
+
+Query for insulin delivery samples. The options object is used to setup a query to retrieve relevant samples.
+
+Example input options:
+
+```javascript
+let options = {
+  startDate: new Date(2021, 0, 0).toISOString(), // required
+  endDate: new Date().toISOString(), // optional; default now
+  ascending: false, // optional; default false
+  limit: 10, // optional; default no limit
+}
+```
+
+Insulin delivery samples are always in International Units.
+
+```javascript
+AppleHealthKit.getInsulinDeliverySamples(
+    options,
+    (callbackError: string, results: HealthValue[]) => {
+        console.log(results)
+    },
+);
+```
+
+Example output:
+
+```json
+[
+  {
+    "id": "8DE6A905-02B7-41D2-BB6E-67D1DD82DD6F", // The universally unique identifier (UUID) for this HealthKit object.
+    "endDate": "2021-03-22T16:19:00.000-0300",
+    "sourceId": "com.apple.Health",
+    "sourceName": "Health",
+    "startDate": "2021-03-22T16:19:00.000-0300",
+    "value": 5,
+    "metadata": {
+      "HKWasUserEntered": true,
+      "HKInsulinDeliveryReason": 2, // Basal = 1, Bolus = 2
+    }
+  }
+]
+```

--- a/docs/saveInsulinDeliverySample.md
+++ b/docs/saveInsulinDeliverySample.md
@@ -1,4 +1,4 @@
-# saveBloodGlucoseSample
+# saveInsulinDeliverySample
 
 Save a insulin delivery value to HealthKit.
 

--- a/docs/saveInsulinDeliverySample.md
+++ b/docs/saveInsulinDeliverySample.md
@@ -1,0 +1,42 @@
+# saveBloodGlucoseSample
+
+Save a insulin delivery value to HealthKit.
+
+`saveInsulinDeliverySample` accepts an options object containing insulin sample data and a callback:
+
+Example input object:
+
+```javascript
+let input = {
+    value: 10, // IU
+    startDate: '2021-03-22T16:19:00.000-0300', // Optional, defaults to now
+    endDate: '2021-03-22T16:19:00.000-0300', // Optional, defaults to startDate
+    metadata: {
+      HKBloodGlucoseMealTime: 1, //Basal = 1, Bolus = 2
+      anyOtherKey: 'some data', // supports string, number, boolean
+    }
+}
+```
+
+Insulin delivery samples are always in International Units.
+
+Example usage:
+
+```javascript
+AppleHealthKit.saveInsulinDeliverySample(
+  input,
+  (err: Object, result: string) => {
+    if (err) {
+      return
+    }
+    // insulin delivery successfully saved
+    console.log(result)
+  },
+)
+```
+
+Example output (record's UUID):
+
+```json
+"619E37D3-C675-4186-B6A4-395EBFC6F46D"
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -437,6 +437,12 @@ declare module 'react-native-health' {
       callback: (err: string, results: Array<HealthActivitySummary>) => void,
     ): void
 
+    getInsulinDeliverySamples(
+      options: HealthInputOptions,
+      callback: (err: string, results: Array<HealthValue>) => void,
+    ): void
+
+
     Constants: Constants
   }
 
@@ -708,6 +714,7 @@ declare module 'react-native-health' {
     Folate = 'Folate',
     HeadphoneAudioExposure = 'HeadphoneAudioExposure',
     ImmunizationRecord = 'ImmunizationRecord',
+    InsulinDelivery = 'InsulinDelivery',
     Iodine = 'Iodine',
     Iron = 'Iron',
     LabResultRecord = 'LabResultRecord',
@@ -843,6 +850,11 @@ declare module 'react-native-health' {
   export enum BloodGlucoseMealTime {
     Preprandial = 1,
     Postprandial = 2,
+  }
+
+  export enum InsulinDeliveryReason {
+    Basal = 1,
+    Bolus = 2,
   }
 
   const appleHealthKit: AppleHealthKit

--- a/index.d.ts
+++ b/index.d.ts
@@ -447,6 +447,11 @@ declare module 'react-native-health' {
       callback: (err: string, results: HealthValue) => void,
     ): void
 
+    deleteInsulinDeliverySample(
+      id: string,
+      callback: (error: string, result: HealthValue) => void,
+    ): void
+
 
     Constants: Constants
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -442,6 +442,11 @@ declare module 'react-native-health' {
       callback: (err: string, results: Array<HealthValue>) => void,
     ): void
 
+    saveInsulinDeliverySample(
+      options: HealthValueOptions,
+      callback: (err: string, results: HealthValue) => void,
+    ): void
+
 
     Constants: Constants
   }
@@ -470,6 +475,7 @@ declare module 'react-native-health' {
 
   export interface RecordMetadata {
     HKBloodGlucoseMealTime?: BloodGlucoseMealTime
+    HKInsulinDeliveryReason?: InsulinDeliveryReason
     HKWasUserEntered?: boolean
     [key: string]: string | number | boolean | undefined
   }

--- a/src/constants/Permissions.js
+++ b/src/constants/Permissions.js
@@ -40,6 +40,7 @@ export const Permissions = {
   Folate: 'Folate',
   HeadphoneAudioExposure: 'HeadphoneAudioExposure',
   ImmunizationRecord: 'ImmunizationRecord',
+  InsulinDelivery: 'InsulinDelivery',
   Iodine: 'Iodine',
   Iron: 'Iron',
   LabResultRecord: 'LabResultRecord',


### PR DESCRIPTION
## Description

This PR adds support for "Insulin Delivery" samples, including fetch, save and delete. It also enables background observing for this type of sample.

Fixes #317 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
