### PR TITLE
feat: Add activities info to workout samples

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -16,6 +16,8 @@ import RNHealthKit, {
   Interval,
   WorkoutActivityType,
   WorkoutMetadataKey,
+  WorkoutSessionLocationType,
+  WorkoutSwimmingLocationType,
 } from 'react-native-health';
 
 RNHealthKit.initHealthKit(
@@ -63,16 +65,48 @@ async function runWorkoutQuery() {
   const result = await RNHealthKit.getWorkouts({
     startDate: new Date(2023, 7, 1).toISOString(),
     endDate: new Date().toISOString(),
-    activityTypes: [WorkoutActivityType.Pickleball],
+    activityTypes: [WorkoutActivityType.SwimBikeRun],
   });
   console.log(result);
 }
 
 async function saveWorkout() {
+  // Workout configurations
+  const conf1 = {
+    workoutActivityType: WorkoutActivityType.Swimming,
+    workoutLocationType: WorkoutSessionLocationType.Outdoor,
+    workoutSwimmingLocationType: WorkoutSwimmingLocationType.OpenWater,
+  };
+
+  const conf2 = {
+    workoutActivityType: WorkoutActivityType.Running,
+    workoutLocationType: WorkoutSessionLocationType.Outdoor,
+    workoutSwimmingLocationType: WorkoutSwimmingLocationType.Unknown,
+  };
+
+  // Workout activities
+  const activity1 = {
+    workoutConfiguration: conf1,
+    startDate: new Date(2023, 8, 8, 4, 0).toISOString(),
+    endDate: new Date(2023, 8, 8, 4, 6).toISOString(),
+    metadata: null,
+  };
+
+  const activity2 = {
+    workoutConfiguration: conf2,
+    startDate: new Date(2023, 8, 8, 4, 10).toISOString(), // 5 minutes ago
+    endDate: new Date(2023, 8, 8, 4, 15).toISOString(), // 1 minute ago
+    metadata: null,
+  };
+
+  // Array of activities
+  const activities = [activity1, activity2];
+
   const result = await RNHealthKit.saveWorkout({
-    activityType: WorkoutActivityType.Pickleball,
+    activityType: WorkoutActivityType.SwimBikeRun,
     startDate: new Date(2023, 8, 8, 4).toISOString(),
     endDate: new Date(2023, 8, 8, 5).toISOString(),
+    activities: activities,
     metadata: {
       [WorkoutMetadataKey.IndoorWorkout]: false,
       [WorkoutMetadataKey.FitnessMachineDuration]: {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -71,7 +71,6 @@ async function runWorkoutQuery() {
 }
 
 async function saveWorkout() {
-  // Workout configurations
   const conf1 = {
     workoutActivityType: WorkoutActivityType.Swimming,
     workoutLocationType: WorkoutSessionLocationType.Outdoor,
@@ -84,7 +83,6 @@ async function saveWorkout() {
     workoutSwimmingLocationType: WorkoutSwimmingLocationType.Unknown,
   };
 
-  // Workout activities
   const activity1 = {
     workoutConfiguration: conf1,
     startDate: new Date(2023, 8, 8, 4, 0).toISOString(),
@@ -94,12 +92,11 @@ async function saveWorkout() {
 
   const activity2 = {
     workoutConfiguration: conf2,
-    startDate: new Date(2023, 8, 8, 4, 10).toISOString(), // 5 minutes ago
-    endDate: new Date(2023, 8, 8, 4, 15).toISOString(), // 1 minute ago
+    startDate: new Date(2023, 8, 8, 4, 10).toISOString(),
+    endDate: new Date(2023, 8, 8, 4, 15).toISOString(),
     metadata: null,
   };
 
-  // Array of activities
   const activities = [activity1, activity2];
 
   const result = await RNHealthKit.saveWorkout({

--- a/index.ts
+++ b/index.ts
@@ -385,15 +385,15 @@ export enum WorkoutActivityType {
 }
 
 export enum WorkoutSessionLocationType {
-  unknown = 1,
-  indoor = 2,
-  outdoor = 3
+  Unknown = 1,
+  Indoor = 2,
+  Outdoor = 3
 }
 
 export enum WorkoutSwimmingLocationType {
-  unknown = 0,
-  pool = 1,
-  openWater = 2
+  Unknown = 0,
+  Pool = 1,
+  OpenWater = 2
 }
 
 export interface WorkoutConfiguration {
@@ -441,8 +441,8 @@ export type QuantityType = {
 }
 
 export enum WaterSalinityType {
-  freshWater = 0,
-  saltWater = 1,
+  FreshWater = 0,
+  SaltWater = 1,
 }
 
 export type WorkoutMetadata = {

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ interface RNHealthKit {
       totalEnergyBurned?: number;
       totalDistance?: number;
       metadata?: WorkoutMetadata;
+      activities?: WorkoutActivity[] | null;
     }
   ): Promise<boolean>;
 }
@@ -377,9 +378,36 @@ export enum WorkoutActivityType {
   SocialDance = 78,    // Dances done in social settings like swing, salsa and folk dances from different world regions.
   Pickleball = 79,
   Cooldown = 80,    // Low intensity stretching and mobility exercises following a more vigorous workout type
-  SwimBikeRun = 81,
-  Transition = 82,
+  SwimBikeRun = 82,
+  Transition = 83,
+  UnderwaterDiving = 84,
   Other = 3000,
+}
+
+export enum WorkoutSessionLocationType {
+  unknown = 1,
+  indoor = 2,
+  outdoor = 3
+}
+
+export enum WorkoutSwimmingLocationType {
+  unknown = 0,
+  pool = 1,
+  openWater = 2
+}
+
+export interface WorkoutConfiguration {
+  workoutActivityType?: WorkoutActivityType | null; 
+  workoutLocationType?: WorkoutSessionLocationType | null;
+  workoutSwimmingLocationType?: WorkoutSwimmingLocationType | null;
+  workoutLapLength?: QuantityType | null; 
+}
+
+export interface WorkoutActivity {
+  workoutConfiguration: WorkoutConfiguration;
+  startDate: Date;
+  endDate?: Date | null;
+  metadata?: { [key: string]: any } | null;
 }
 
 export enum WorkoutMetadataKey {

--- a/v2/RNHealthKitCore/HealthKitCore.xcodeproj/project.pbxproj
+++ b/v2/RNHealthKitCore/HealthKitCore.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		7E9A84F52A544A1A004622E5 /* QuantityQueriesParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9A84F42A544A1A004622E5 /* QuantityQueriesParameters.swift */; };
 		7E9A84F72A548A39004622E5 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9A84F62A548A39004622E5 /* Utils.swift */; };
 		D31BF2482B10FC7C00005EE7 /* WorkoutHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31BF2472B10FC7C00005EE7 /* WorkoutHelper.swift */; };
+		D3785B392B16494A00B8C30A /* WorkoutActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3785B382B16494A00B8C30A /* WorkoutActivity.swift */; };
+		D3785B3D2B16558800B8C30A /* Quantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3785B3C2B16558800B8C30A /* Quantity.swift */; };
+		D3785B412B17996E00B8C30A /* WorkoutConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3785B402B17996E00B8C30A /* WorkoutConfiguration.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,6 +51,9 @@
 		7EB70C892A61ABAF003EE217 /* RNHealthKitWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNHealthKitWrapper.m; sourceTree = "<group>"; };
 		7EE4AA502A669CA200CC9EEF /* RNHealthKitWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNHealthKitWrapper.swift; sourceTree = "<group>"; };
 		D31BF2472B10FC7C00005EE7 /* WorkoutHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutHelper.swift; sourceTree = "<group>"; };
+		D3785B382B16494A00B8C30A /* WorkoutActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutActivity.swift; sourceTree = "<group>"; };
+		D3785B3C2B16558800B8C30A /* Quantity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quantity.swift; sourceTree = "<group>"; };
+		D3785B402B17996E00B8C30A /* WorkoutConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkoutConfiguration.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,10 +80,13 @@
 		7E4BFFE42A9FC0D500FB1383 /* Workout */ = {
 			isa = PBXGroup;
 			children = (
+				D3785B402B17996E00B8C30A /* WorkoutConfiguration.swift */,
 				7E4BFFE92AAA423100FB1383 /* WorkoutSample.swift */,
 				7E4BFFE52A9FC0ED00FB1383 /* WorkoutQueries.swift */,
 				7E4BFFE72AAA421200FB1383 /* WorkoutQueryParameters.swift */,
 				D31BF2472B10FC7C00005EE7 /* WorkoutHelper.swift */,
+				D3785B382B16494A00B8C30A /* WorkoutActivity.swift */,
+				D3785B3C2B16558800B8C30A /* Quantity.swift */,
 			);
 			path = Workout;
 			sourceTree = "<group>";
@@ -183,7 +192,10 @@
 				7E9A84F52A544A1A004622E5 /* QuantityQueriesParameters.swift in Sources */,
 				7E9A84F32A5449C2004622E5 /* HealthKitTypes.swift in Sources */,
 				7E9A84CC2A5312D7004622E5 /* HealthKitCore.swift in Sources */,
+				D3785B3D2B16558800B8C30A /* Quantity.swift in Sources */,
 				D31BF2482B10FC7C00005EE7 /* WorkoutHelper.swift in Sources */,
+				D3785B392B16494A00B8C30A /* WorkoutActivity.swift in Sources */,
+				D3785B412B17996E00B8C30A /* WorkoutConfiguration.swift in Sources */,
 				7E5AEBB32A5EAF2800F74829 /* QuantityQueries.swift in Sources */,
 				7E4BFFEE2AAA6D6D00FB1383 /* QueryParameters.swift in Sources */,
 				7E4BFFEA2AAA423100FB1383 /* WorkoutSample.swift in Sources */,

--- a/v2/RNHealthKitCore/HealthKitCore/Workout/Quantity.swift
+++ b/v2/RNHealthKitCore/HealthKitCore/Workout/Quantity.swift
@@ -1,0 +1,37 @@
+import Foundation
+import HealthKit
+
+public struct WorkoutQuantity: Codable {
+    public let unit: HKUnit
+    public let doubleValue: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case unit
+        case doubleValue
+    }
+
+    public init(unit: HKUnit, doubleValue: Double) {
+        self.unit = unit
+        self.doubleValue = doubleValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let unitString = try container.decode(String.self, forKey: .unit)
+        let doubleValue = try container.decode(Double.self, forKey: .doubleValue)
+        self.unit = HKUnit(from: unitString)
+        self.doubleValue = doubleValue
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(unit.unitString, forKey: .unit)
+        try container.encode(doubleValue, forKey: .doubleValue)
+    }
+}
+
+extension HKQuantity {
+    public convenience init(quantity: WorkoutQuantity) {
+        self.init(unit: quantity.unit, doubleValue: quantity.doubleValue)
+    }
+}

--- a/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutActivity.swift
+++ b/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutActivity.swift
@@ -1,0 +1,69 @@
+import Foundation
+import HealthKit
+
+public struct WorkoutActivity: Codable {
+    public let workoutConfiguration: WorkoutConfiguration
+    public let startDate: String
+    public let endDate: String?
+    public let metadata: [String: Any]?
+
+    private enum CodingKeys: String, CodingKey {
+        case workoutConfiguration
+        case startDate
+        case endDate
+        case metadata
+    }
+
+    public init(
+        workoutConfiguration: WorkoutConfiguration,
+        startDate: String,
+        endDate: String?,
+        metadata: [String: Any]? = nil
+    ) {
+        self.workoutConfiguration = workoutConfiguration
+        self.startDate = startDate
+        self.endDate = endDate
+        self.metadata = metadata
+    }
+
+    @available(iOS 16.0, *)
+    public init(activity: HKWorkoutActivity) {
+        let configuration = activity.workoutConfiguration
+        self.init(
+            workoutConfiguration: .init(
+                workoutActivityType: configuration.activityType,
+                workoutLocationType: configuration.locationType,
+                workoutSwimmingLocationType: configuration.swimmingLocationType
+            ),
+            startDate: activity.startDate.toIsoString()!,
+            endDate: activity.endDate?.toIsoString(),
+            metadata: activity.metadata
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(workoutConfiguration, forKey: .workoutConfiguration)
+        try container.encode(startDate, forKey: .startDate)
+        try container.encodeIfPresent(endDate, forKey: .endDate)
+
+        if let metadata = metadata {
+            let jsonData = try JSONSerialization.data(withJSONObject: metadata, options: [])
+            try container.encode(jsonData, forKey: .metadata)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workoutConfiguration = try container.decode(WorkoutConfiguration.self, forKey: .workoutConfiguration)
+        startDate = try container.decode(String.self, forKey: .startDate)
+        endDate = try container.decodeIfPresent(String.self, forKey: .endDate)
+
+        if let metadataData = try container.decodeIfPresent(Data.self, forKey: .metadata) {
+            metadata = try JSONSerialization.jsonObject(with: metadataData, options: []) as? [String: Any]
+        } else {
+            metadata = nil
+        }
+    }
+}

--- a/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutConfiguration.swift
+++ b/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutConfiguration.swift
@@ -1,0 +1,64 @@
+import Foundation
+import HealthKit
+
+public struct WorkoutConfiguration: Codable {
+    public let workoutActivityType: HKWorkoutActivityType?
+    public let workoutLocationType: HKWorkoutSessionLocationType?
+    public let workoutSwimmingLocationType: HKWorkoutSwimmingLocationType?
+    public let workoutLapLength: WorkoutQuantity?
+
+    private enum CodingKeys: String, CodingKey {
+        case workoutActivityType
+        case workoutLocationType
+        case workoutSwimmingLocationType
+        case workoutLapLength
+    }
+
+    public init(
+        workoutActivityType: HKWorkoutActivityType? = .other,
+        workoutLocationType: HKWorkoutSessionLocationType = .unknown,
+        workoutSwimmingLocationType: HKWorkoutSwimmingLocationType? = nil,
+        workoutLapLength: WorkoutQuantity? = nil
+    ) {
+        self.workoutActivityType = workoutActivityType
+        self.workoutLocationType = workoutLocationType
+        self.workoutSwimmingLocationType = workoutSwimmingLocationType
+        self.workoutLapLength = workoutLapLength
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(workoutActivityType?.rawValue, forKey: .workoutActivityType)
+        try container.encodeIfPresent(workoutLocationType?.rawValue, forKey: .workoutLocationType)
+        try container.encodeIfPresent(workoutSwimmingLocationType?.rawValue, forKey: .workoutSwimmingLocationType)
+        try container.encodeIfPresent(workoutLapLength, forKey: .workoutLapLength)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let workoutActivityTypeRawValue = try container.decodeIfPresent(Int.self, forKey: .workoutActivityType)
+        let locationTypeRawValue = try container.decodeIfPresent(Int.self, forKey: .workoutLocationType)
+        let swimmingLocationTypeRawValue = try container.decodeIfPresent(Int.self, forKey: .workoutSwimmingLocationType)
+        let lapLength = try container.decodeIfPresent(WorkoutQuantity.self, forKey: .workoutLapLength)
+
+        if let rawActivityRawValue = workoutActivityTypeRawValue {
+            self.workoutActivityType = HKWorkoutActivityType(rawValue: UInt(rawActivityRawValue))
+        } else {
+            self.workoutActivityType = nil
+        }
+
+        if let rawLocationTypeValue = locationTypeRawValue {
+            self.workoutLocationType = HKWorkoutSessionLocationType(rawValue: rawLocationTypeValue)
+        } else {
+            self.workoutLocationType = .unknown
+        }
+
+        if let rawSwimmingLocationTypeValue = swimmingLocationTypeRawValue {
+            self.workoutSwimmingLocationType = HKWorkoutSwimmingLocationType(rawValue: rawSwimmingLocationTypeValue)
+        } else {
+            self.workoutSwimmingLocationType = nil
+        }
+
+        self.workoutLapLength = lapLength
+    }
+}

--- a/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutQueries.swift
+++ b/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutQueries.swift
@@ -45,6 +45,88 @@ public extension HealthKitCore {
         totalDistance: Double?,
         metadata: [String: Any]?
     ) async throws -> HKWorkout? {
+        try await handleSaveCompletedWorkout(
+            activityType: activityType,
+            startDate: startDate,
+            endDate: endDate,
+            totalEnergyBurned: totalEnergyBurned,
+            totalDistance: totalDistance,
+            metadata: metadata,
+            completion: nil
+        )
+    }
+
+    /// Saves a completed workout to HealthKit with specified parameters and additional activities.
+    /// - Parameters:
+    ///   - activityType: The type of physical activity for the workout.
+    ///   - startDate: The start date and time of the workout.
+    ///   - endDate: The end date and time of the workout.
+    ///   - totalEnergyBurned: The total energy burned during the workout (in kilocalories).
+    ///   - totalDistance: The total distance covered during the workout (in kilometers).
+    ///   - activities: Optional array of `WorkoutActivity` to include in the workout.
+    ///   - metadata: Optional metadata for the workout.
+    /// - Throws: An error if the workout data cannot be saved to HealthKit.
+    @available(iOS 16.0, *)
+    func saveCompletedWorkout(
+        activityType: HKWorkoutActivityType,
+        startDate: Date,
+        endDate: Date,
+        totalEnergyBurned: Double?,
+        totalDistance: Double?,
+        activities: [WorkoutActivity]?,
+        metadata: [String: Any]?
+    ) async throws -> HKWorkout? {
+        let handleActivities: ((HKWorkoutConfiguration, HKWorkoutBuilder) async throws -> Void)? = activities != nil ? { configuration, builder in
+            if let activities {
+                for activity in activities {
+                    let workoutConfiguration = activity.workoutConfiguration
+                    if let activityType = workoutConfiguration.workoutActivityType {
+                        configuration.activityType = activityType
+                    }
+
+                    if let locationType = workoutConfiguration.workoutLocationType {
+                        configuration.locationType = locationType
+                    }
+
+                    if let swimmingLocationType = workoutConfiguration.workoutSwimmingLocationType {
+                        configuration.swimmingLocationType = swimmingLocationType
+                    }
+
+                    if let lapLength = workoutConfiguration.workoutLapLength {
+                        configuration.lapLength = HKQuantity(quantity: lapLength)
+                    }
+                    try await builder.addWorkoutActivity(
+                        HKWorkoutActivity(
+                            workoutConfiguration: configuration,
+                            start: activity.startDate.fromIsoStringToDate(),
+                            end: activity.endDate?.fromIsoStringToDate(),
+                            metadata: activity.metadata
+                        )
+                    )
+                }
+            }
+        } : nil
+
+        return try await handleSaveCompletedWorkout(
+            activityType: activityType,
+            startDate: startDate,
+            endDate: endDate,
+            totalEnergyBurned: totalEnergyBurned,
+            totalDistance: totalDistance,
+            metadata: metadata,
+            completion: handleActivities
+        )
+    }
+
+    private func handleSaveCompletedWorkout(
+        activityType: HKWorkoutActivityType,
+        startDate: Date,
+        endDate: Date,
+        totalEnergyBurned: Double?,
+        totalDistance: Double?,
+        metadata: [String: Any]?,
+        completion: ((HKWorkoutConfiguration, HKWorkoutBuilder) async throws -> Void)?
+    ) async throws -> HKWorkout? {
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = activityType
         let workoutBuilder = HKWorkoutBuilder(healthStore: healthStore, configuration: configuration, device: .local())
@@ -73,6 +155,8 @@ public extension HealthKitCore {
             )
             samples.append(distanceSample)
         }
+
+        try await completion?(configuration, workoutBuilder)
 
         if let metadata {
             try await workoutBuilder.addMetadata(metadata)

--- a/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutSample.swift
+++ b/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutSample.swift
@@ -18,10 +18,12 @@ public struct WorkoutSample: Encodable {
     /// The activity type of the workout as a raw unsigned integer value.
     public let activityType: UInt
     
+    // Representing additional activities that are part of the workout.
+    public let workoutActivities: [WorkoutActivity]?
+
     /// Additional metadata associated with the workout sample.
     public let metadata: [String: String]?
 
-    // TODO: Add activities | var workoutActivities: [HKWorkoutActivity]
     // TODO: Add workout events | var workoutEvents: [HKWorkoutEvent]?
     // TODO: Add statistics public var statistics: [QuantityType : QuantitySample]
 
@@ -34,6 +36,12 @@ public struct WorkoutSample: Encodable {
         self.endDate = workout.endDate.toIsoString() ?? ""
         self.duration = workout.duration
         self.activityType = workout.workoutActivityType.rawValue
+
+        if #available(iOS 16.0, *) {
+            workoutActivities = workout.workoutActivities.compactMap({ WorkoutActivity(activity: $0) })
+        } else {
+            workoutActivities = nil
+        }
         self.metadata = workout.metadata?.mapValues(String.init(describing:)) ?? [:]
     }
 }

--- a/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutSample.swift
+++ b/v2/RNHealthKitCore/HealthKitCore/Workout/WorkoutSample.swift
@@ -18,7 +18,7 @@ public struct WorkoutSample: Encodable {
     /// The activity type of the workout as a raw unsigned integer value.
     public let activityType: UInt
     
-    // Representing additional activities that are part of the workout.
+    // Represents additional activities that are part of the workout.
     public let workoutActivities: [WorkoutActivity]?
 
     /// Additional metadata associated with the workout sample.

--- a/v2/RNHealthKitCore/ReactNativeBridge/RNHealthKitWrapper.swift
+++ b/v2/RNHealthKitCore/ReactNativeBridge/RNHealthKitWrapper.swift
@@ -224,14 +224,33 @@ class RNHealthKitWrapper: NSObject {
                     processedMetadata = try WorkoutHelper.processWorkoutMetadata(metadata)
                 }
 
-                try await core?.saveCompletedWorkout(
-                    activityType: activityType,
-                    startDate: startDate,
-                    endDate: endDate,
-                    totalEnergyBurned: workout["totalEnergyBurned"] as? Double,
-                    totalDistance: workout["totalDistance"] as? Double,
-                    metadata: processedMetadata
-                )
+                let workoutActivities: [WorkoutActivity]
+                if let activities = workout["activities"] {
+                    let activityData = Data(activities)
+                    workoutActivities = try JSONDecoder().decode([WorkoutActivity].self, from: activityData)
+                }
+                
+                if #available(iOS 16.0, *) {
+                    try await core?.saveCompletedWorkout(
+                        activityType: activityType,
+                        startDate: startDate,
+                        endDate: endDate,
+                        totalEnergyBurned: workout["totalEnergyBurned"] as? Double,
+                        totalDistance: workout["totalDistance"] as? Double,
+                        activities: workoutActivities,
+                        metadata: processedMetadata
+                    )
+                } else {
+                    try await core?.saveCompletedWorkout(
+                        activityType: activityType,
+                        startDate: startDate,
+                        endDate: endDate,
+                        totalEnergyBurned: workout["totalEnergyBurned"] as? Double,
+                        totalDistance: workout["totalDistance"] as? Double,
+                        metadata: processedMetadata
+                    )
+                }
+
                 resolve(true)
             } catch {
                 reject("saveWorkout", error.localizedDescription, error)

--- a/v2/RNHealthKitCore/ReactNativeBridge/RNHealthKitWrapper.swift
+++ b/v2/RNHealthKitCore/ReactNativeBridge/RNHealthKitWrapper.swift
@@ -224,12 +224,12 @@ class RNHealthKitWrapper: NSObject {
                     processedMetadata = try WorkoutHelper.processWorkoutMetadata(metadata)
                 }
 
-                let workoutActivities: [WorkoutActivity]
-                if let activities = workout["activities"] {
-                    let activityData = Data(activities)
+                var workoutActivities: [WorkoutActivity]?
+                if let activities = workout["activities"] as? [String: Any] {
+                    let activityData = try JSONSerialization.data(withJSONObject: activities, options: [])
                     workoutActivities = try JSONDecoder().decode([WorkoutActivity].self, from: activityData)
                 }
-                
+
                 if #available(iOS 16.0, *) {
                     try await core?.saveCompletedWorkout(
                         activityType: activityType,

--- a/v2/RNHealthKitCoreApp/RNHealthKitCoreApp/ContentView.swift
+++ b/v2/RNHealthKitCoreApp/RNHealthKitCoreApp/ContentView.swift
@@ -30,28 +30,65 @@ struct ContentView: View {
         }
     }
 
-    func saveWorkoutWithMetadata(core: HealthKitCore) async {
-        let unit = HKUnit(from: "min")
-        let rawMetadata: [String: Any] = [
-            "HKIndoorWorkout": true,
-            "HKFitnessMachineDuration": ["unit": "min", "doubleValue": 30.0],
-        ]
+    private func saveWorkoutWithMetadata(core: HealthKitCore) async throws {
+        let startDate = Calendar(identifier: .gregorian).date(byAdding: .minute, value: -15, to: .now)!
+        let activityStartTime = Calendar(identifier: .gregorian).date(byAdding: .minute, value: -14, to: .now)!
 
-        let processedMetadata = try! WorkoutHelper.processWorkoutMetadata(rawMetadata)
+        let conf1 = WorkoutConfiguration(
+            workoutActivityType: .swimming,
+            workoutLocationType: .outdoor,
+            workoutSwimmingLocationType: .openWater
+        )
+        let conf2 = WorkoutConfiguration(
+            workoutActivityType: .running,
+            workoutLocationType: .outdoor,
+            workoutSwimmingLocationType: .unknown
+        )
 
-        dump(try! await core.saveCompletedWorkout(
-            activityType: .coreTraining,
-            startDate: Calendar(identifier: .gregorian).date(byAdding: .minute, value: -2, to: .now)!,
-            endDate: Date(),
-            totalEnergyBurned: 120,
-            totalDistance: 2000,
-            metadata: processedMetadata
-        ))
+        let activity1 = WorkoutActivity(
+            workoutConfiguration: conf1,
+            startDate: activityStartTime.toIsoString()!,
+            endDate: Calendar(identifier: .gregorian).date(byAdding: .minute, value: -10, to: .now)!.toIsoString(),
+            metadata: nil
+        )
+        let activity2 = WorkoutActivity(
+            workoutConfiguration: conf2,
+            startDate: Calendar(identifier: .gregorian).date(byAdding: .minute, value: -5, to: .now)!.toIsoString()!,
+            endDate: Calendar(identifier: .gregorian).date(byAdding: .minute, value: -1, to: .now)!.toIsoString(),
+            metadata: nil
+        )
+
+        if #available(iOS 16.0, *) {
+            print(try await core.saveCompletedWorkout(
+                activityType: .swimBikeRun,
+                startDate: startDate, endDate: Date(),
+                totalEnergyBurned: 120,
+                totalDistance: 2000,
+                activities: [activity1, activity2],
+                metadata: nil
+            ))
+        } else {
+            print(try await core.saveCompletedWorkout(
+                activityType: .running,
+                startDate: startDate, endDate: Date(),
+                totalEnergyBurned: 120,
+                totalDistance: 2000,
+                metadata: nil
+            ))
+        }
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+    }
+}
+
+private extension Date {
+    func toIsoString() -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        return formatter.string(from: self)
     }
 }


### PR DESCRIPTION
## Description

This PR includes the following changes: 

- Adds workout activity support. Now it's possible to fetch activity information from samples and save these activities on newly created workouts
- Adds support to multiple activities in a single workout. (E.g. `swimBikeRun`)

Fixes #

Fixes issue with `SwimBikeRun`, `Transition`, `UnderwaterDiving` raw values. Updated their values to the correct ones and added the new `UnderwaterDiving` case.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
