### PR TITLE
improve perf 3-5x by avoiding re-instantiating date formatter

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -64,29 +64,31 @@ NSString * const kMetadataKey = @"metadata";
     return formattedWorkEvents;
 }
 
-+ (NSDate *)parseISO8601DateFromString:(NSString *)date
-{
-    @try {
-        NSDateFormatter *dateFormatter = [NSDateFormatter new];
+
++ (NSDateFormatter *)iso8601DateFormatter {
+    static NSDateFormatter *dateFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        dateFormatter = [NSDateFormatter new];
         NSLocale *posix = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
         dateFormatter.locale = posix;
         dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ";
-        return [dateFormatter dateFromString:date];
+    });
+    return dateFormatter;
+}
+
++ (NSDate *)parseISO8601DateFromString:(NSString *)date {
+    @try {
+        return [[RCTAppleHealthKit iso8601DateFormatter] dateFromString:date];
     } @catch (NSException *exception) {
         NSLog(@"RNHealth: An error occured while trying parse ISO8601 date from string");
         return nil;
     }
 }
 
-
-+ (NSString *)buildISO8601StringFromDate:(NSDate *)date
-{
++ (NSString *)buildISO8601StringFromDate:(NSDate *)date {
     @try {
-        NSDateFormatter *dateFormatter = [NSDateFormatter new];
-        NSLocale *posix = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-        dateFormatter.locale = posix;
-        dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ";
-        return [dateFormatter stringFromDate:date];
+        return [[RCTAppleHealthKit iso8601DateFormatter] stringFromDate:date];
     } @catch (NSException *exception) {
         NSLog(@"RNHealth: An error occured while trying parse ISO8601 string from date");
         return nil;


### PR DESCRIPTION
## Description
Querying workouts was taking an unexpectedly long time, so did a perf trace, saw that this code was the culprit:
<img width="601" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/89557c0c-8ba5-4ad8-9726-d9c61115c057">


Modified the code and re-ran my project and saw huge savings.

TBH not sure if this needs more extensive testing (are there unit tests?), but feedback is welcome. 

**BEFORE:**
<img width="495" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/e3c8aee4-8304-4c94-81c8-400c6dd510b2">
<img width="487" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/2f071ec3-4f8e-4db0-a677-4886f48442d7">
<img width="473" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/2f40aa72-6aa5-4347-9b06-324b0bdd5028">
<img width="471" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/2af40afb-8721-4ab1-a43a-23f3ac2b3684">

**AFTER:**
<img width="493" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/af153e77-28bd-4262-bea6-a884560ed19f">
<img width="456" alt="image" src="https://github.com/agencyenterprise/react-native-health/assets/4411839/0397c028-e98e-4ae1-8ae8-08feed4819c8">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
