### PR TITLE
Add delete all mindful sessions method

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Mindfulness.h
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Mindfulness.h
@@ -11,5 +11,6 @@
 
 - (void)mindfulness_getMindfulSession:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
 - (void)mindfulness_saveMindfulSession:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback;
+- (void)mindfulness_deleteAllMindfulSessions:(RCTResponseSenderBlock)callback;
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Mindfulness.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Mindfulness.m
@@ -83,5 +83,38 @@
 
 }
 
+- (void)mindfulness_deleteAllMindfulSessions:(RCTResponseSenderBlock)callback
+{
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:HKSampleSortIdentifierEndDate ascending:false];
+    HKSampleType *mindfulType = [HKObjectType categoryTypeForIdentifier:HKCategoryTypeIdentifierMindfulSession];
+
+    // Get all samples from 1970 until now
+    NSDate *startDate = [NSDate dateWithTimeIntervalSince1970:0];
+    NSDate *endDate = [NSDate date];
+    NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionNone];
+
+    HKSampleQuery *query = [[HKSampleQuery alloc] initWithSampleType:mindfulType predicate:predicate limit:0 sortDescriptors:@[sortDescriptor] resultsHandler:^(HKSampleQuery * _Nonnull query, NSArray<__kindof HKSample *> * _Nullable results, NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"An error occured while deleting the mindful sessions %@. The error was: ", error);
+            callback(@[RCTMakeError(@"An error occured while deleting the glucose sample", error, nil)]);
+            return;
+        }
+        if (results.count == 0) {
+            callback(@[[NSNull null], @0]);
+            return;
+        }
+        [self.healthStore deleteObjects:results withCompletion:^(BOOL success, NSError * _Nullable error) {
+            if (!success) {
+                NSLog(@"An error occured while deleting the mindful sessions %@. The error was: ", error);
+                callback(@[RCTMakeError(@"An error occured while deleting the glucose sample", error, nil)]);
+                return;
+            }
+            callback(@[[NSNull null], @(results.count)]);
+        }];
+    }];
+
+    [self.healthStore executeQuery:query];
+}
+
 
 @end

--- a/RCTAppleHealthKit/RCTAppleHealthKit.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit.m
@@ -549,6 +549,12 @@ RCT_EXPORT_METHOD(saveMindfulSession:(NSDictionary *)input callback:(RCTResponse
     [self mindfulness_saveMindfulSession:input callback:callback];
 }
 
+RCT_EXPORT_METHOD(deleteAllMindfulSessions:(RCTResponseSenderBlock)callback)
+{
+    [self _initializeHealthStore];
+    [self mindfulness_deleteAllMindfulSessions:(RCTResponseSenderBlock)callback];
+}
+
 RCT_EXPORT_METHOD(saveWorkout:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback)
 {
     [self _initializeHealthStore];

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ All the documentation is under the [docs](/docs) folder. They are split into the
 
 - [getMindfulSession](docs/getMindfulSession.md)
 - [saveMindfulSession](/docs/saveMindfulSession.md)
+- [deleteAllMindfulSessions](/docs/deleteAllMindfulSessions.md)
 
 ### Sleep Methods
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -96,6 +96,7 @@
 
 * [getMindfulSession](docs/getMindfulSession.md)
 * [saveMindfulSession](/docs/saveMindfulSession.md)
+* [deleteAllMindfulSessions](/docs/deleteAllMindfulSessions.md)
 
 ## Sleep Methods
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@
 
 - [getMindfulSession](docs/getMindfulSession.md)
 - [saveMindfulSession](saveMindfulSession.md)
+- [deleteAllMindfulSessions](deleteAllMindfulSessions.md)
 
 ### Sleep Methods
 

--- a/docs/deleteAllMindfulSessions.md
+++ b/docs/deleteAllMindfulSessions.md
@@ -1,0 +1,24 @@
+# deleteAllMindfulSessions
+
+Delete all mindful sessions from HealthKit.
+
+`deleteAllMindfulSessions` accepts a callback:
+
+Example usage:
+
+```javascript
+AppleHealthKit.deleteAllMindfulSessions((err: string, result: number) => {
+  if (err) {
+    console.log(err)
+    return
+  }
+  // sample successfully deleted
+  console.log(result)
+})
+```
+
+Example output (if 20 objects are deleted):
+
+```json
+20
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -365,6 +365,10 @@ declare module 'react-native-health' {
       callback: (error: string, result: HealthValue) => void,
     ): void
 
+    deleteAllMindfulSessions(
+      callback: (error: string, result: number) => void,
+    ): void
+
     getWorkoutRouteSamples(
       options: { id: string },
       callback: (err: string, results: WorkoutRouteQueryResults) => void,
@@ -462,7 +466,6 @@ declare module 'react-native-health' {
       callback: (error: string, result: HealthValue) => void,
     ): void
 
-
     Constants: Constants
   }
 
@@ -546,7 +549,7 @@ declare module 'react-native-health' {
     PausedOrResumeRequest = 'pause or resume request',
     Lap = 'lap',
     Segment = 'segment',
-    Marker = 'marker'
+    Marker = 'marker',
   }
 
   export type HKWorkoutEventType = {


### PR DESCRIPTION
## Description

in our app we needed a functionality to remove all the mindful session that we have stored for the user at once. since that functionality was not provided by the library. I decided to add the function `deleteAllMindfulSessions` and make the PR for it.

Fixes # ( no issue created yet )

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
