### PR TITLE
feat: include sleep metadata results

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -611,6 +611,8 @@
 
                     NSString *valueString;
 
+                    NSObject*metaData = [sample metadata] ? [sample metadata] : @{};
+
                     switch (val) {
                       case HKCategoryValueSleepAnalysisInBed:
                         valueString = @"INBED";
@@ -643,6 +645,7 @@
                             @"value" : valueString,
                             @"startDate" : startDateString,
                             @"endDate" : endDateString,
+                            @"metadata" : metaData,
                             @"sourceName" : [[[sample sourceRevision] source] name],
                             @"sourceId" : [[[sample sourceRevision] source] bundleIdentifier],
                     };


### PR DESCRIPTION
## Description

Include metadata object when querying data from getSleepSamples. This allows us to receive HKTimezone.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have checked my code and corrected any misspellings
