### PR TITLE
Accept different units on getWaterSamples

### DIFF
--- a/docs/units.md
+++ b/docs/units.md
@@ -25,4 +25,11 @@ The following units are supported by the library
   pound
   second
   mlPerKgMin
+  liter
+  fluidOunceUSnceUS
+  fluidOunceImperialnceImperial
+  cupUS
+  cupImperialrial
+  pintUS
+  pintImperialerial
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -837,6 +837,13 @@ declare module 'react-native-health' {
     percent = 'percent',
     pound = 'pound',
     second = 'second',
+    liter = 'liter',
+    fluidOunceUS = 'fluidOunceUS',
+    fluidOunceImperial = 'fluidOunceImperial',
+    cupUS = 'cupUS',
+    cupImperial = 'cupImperial',
+    pintUS = 'pintUS',
+    pintImperial = 'pintImperial',
   }
 
   export enum HealthStatusCode {

--- a/src/constants/Units.js
+++ b/src/constants/Units.js
@@ -26,4 +26,11 @@ export const Units = {
   pound: 'pound',
   second: 'second',
   mlPerKgMin: 'mlPerKgMin',
+  liter: 'liter',
+  fluidOunceUSnceUS: 'fluidOunceUSnceUS',
+  fluidOunceImperialnceImperial: 'fluidOunceImperialnceImperial',
+  cupUS: 'cupUS',
+  cupImperialrial: 'cupImperialrial',
+  pintUS: 'pintUS',
+  pintImperialerial: 'pintImperialerial',
 }


### PR DESCRIPTION
## Description
Currently, the getWaterSamples function in the react-native-health library only retrieves water samples using a fixed unit (defaulting to liters). However, users may want to retrieve water samples using different units such as fluid ounces, cups, or pints. This enhancement provides users with the flexibility to specify their desired unit for water samples, improving the usability and versatility of the library.

Fixes #365 (Accept different units on the getWaterSamples function)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
