### PR TITLE
feat: Add sources metadata to statistics collection query

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -935,7 +935,7 @@
     // Create the query
     HKStatisticsCollectionQuery *query = [[HKStatisticsCollectionQuery alloc] initWithQuantityType:quantityType
                                                                            quantitySamplePredicate:predicate
-                                                                                           options:HKStatisticsOptionCumulativeSum
+                                                                                           options:HKStatisticsOptionCumulativeSum | HKStatisticsOptionSeparateBySource
                                                                                         anchorDate:anchorDate
                                                                                 intervalComponents:interval];
 
@@ -961,10 +961,33 @@
                                            NSString *startDateString = [RCTAppleHealthKit buildISO8601StringFromDate:startDate];
                                            NSString *endDateString = [RCTAppleHealthKit buildISO8601StringFromDate:endDate];
 
+                                           NSMutableArray *metadata = [NSMutableArray arrayWithCapacity:1];
+
+                                           for (HKSource *source in result.sources) {
+
+                                                NSString *bundleIdentifier = source.bundleIdentifier;
+                                                NSString *name = source.name;
+                                                HKQuantity *sourceQuantity = [result sumQuantityForSource:source];
+                                                double quantity = [sourceQuantity doubleValueForUnit:unit];
+
+
+                                                if (quantity != 0) {
+                                                    NSDictionary *sourceItem = @{
+                                                                                @"sourceId" : bundleIdentifier,
+                                                                                @"sourceName" : name,
+                                                                                @"quantity" : @(quantity), 
+                                                                                };
+
+                                                    [metadata addObject:sourceItem];
+                                                }
+                                            }
+                                
+
                                            NSDictionary *elem = @{
                                                    @"value" : @(value),
                                                    @"startDate" : startDateString,
                                                    @"endDate" : endDateString,
+                                                   @"metadata" : metadata,
                                            };
                                            [data addObject:elem];
                                        }
@@ -1214,3 +1237,4 @@
 }
 
 @end
+

--- a/docs/getDailyStepCountSamples.md
+++ b/docs/getDailyStepCountSamples.md
@@ -32,7 +32,14 @@ Example output, value is on count unit:
   {
     "endDate": "2021-03-22T17:00:00.000-0300",
     "startDate": "2021-03-22T16:00:00.000-0300",
-    "value": 3978
+    "value": 3978,
+    "metadata": [
+      {
+        "sourceId": "com.apple.Health",
+        "sourceName": "Health",
+        "quantity": 3978
+      }
+    ]
   }
 ]
 ```


### PR DESCRIPTION
## Description

For the statistics collection query, HealthKit partitions the matching samples into a set of time intervals and performs the calculations over each interval separately. By default, this query automatically merges the data from all of your data sources before performing the calculations. 

This PR introduces the capability to **request statistical data separately for each data source**, by setting the  [HKStatisticsOptionSeparateBySource](https://developer.apple.com/documentation/healthkit/hkstatisticsoptions/hkstatisticsoptionseparatebysource?language=objc) option.

This is particularly valuable for scenarios where understanding the contribution of each individual data source is crucial (e.g., understanding how different devices or apps contribute to the total daily step count).

PS: I've only updated the `getDailyStepCountSamples` documentation with the new output data, but I can update other docs if this feature proves valuable.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
