### PR TITLE
fix: missing type declarations for HealthActivityOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -592,6 +592,10 @@ declare module 'react-native-health' {
   export interface HealthActivityOptions
     extends Omit<Omit<HealthValueOptions, 'unit'>, 'value'> {
     type: HealthActivity
+    distance: number
+    distanceUnit: 'meter' | 'cm' | 'inch' | 'mile' | 'foot'
+    energyBurned?: number
+    energyBurnedUnit?: 'joule' | 'calorie'
   }
 
   export interface HealthObserverOptions {


### PR DESCRIPTION
## Description

The Types of the `saveWorkout` method were not correct:

https://github.com/agencyenterprise/react-native-health/blob/master/docs/saveWorkout.md

<img width="957" alt="image" src="https://github.com/user-attachments/assets/3e14cc8c-07a3-4387-ba88-e3b0736be299">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
